### PR TITLE
Fix submesh handling in URDF importer in ROS2 Gem.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -59,13 +59,13 @@ namespace ROS2
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetVector3Value,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::Rotation,
+                    PhysX::JointsComponentModeCommon::ParameterNames::Rotation,
                     rotation);
 
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetLinearValuePair,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::LinearLimits,
+                    PhysX::JointsComponentModeCommon::ParameterNames::LinearLimits,
                     PhysX::AngleLimitsFloatPair(joint->limits->upper, joint->limits->lower));
 
                 followColliderEntity->Deactivate();
@@ -80,11 +80,11 @@ namespace ROS2
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     [&rotation](PhysX::EditorJointRequests* editorJointRequest)
                     {
-                        editorJointRequest->SetVector3Value(PhysX::JointsComponentModeCommon::ParamaterNames::Rotation, rotation);
+                        editorJointRequest->SetVector3Value(PhysX::JointsComponentModeCommon::ParameterNames::Rotation, rotation);
                         editorJointRequest->SetLinearValuePair(
-                            PhysX::JointsComponentModeCommon::ParamaterNames::TwistLimits,
+                            PhysX::JointsComponentModeCommon::ParameterNames::TwistLimits,
                             PhysX::AngleLimitsFloatPair(AZ::RadToDeg(AZ::Constants::TwoPi), -AZ::RadToDeg(AZ::Constants::TwoPi)));
-                        editorJointRequest->SetBoolValue(PhysX::JointsComponentModeCommon::ParamaterNames::EnableLimits, false);
+                        editorJointRequest->SetBoolValue(PhysX::JointsComponentModeCommon::ParameterNames::EnableLimits, false);
                     });
                 followColliderEntity->Deactivate();
             }
@@ -107,9 +107,9 @@ namespace ROS2
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     [&rotation, &limitLower, &limitUpper](PhysX::EditorJointRequests* editorJointRequest)
                     {
-                        editorJointRequest->SetVector3Value(PhysX::JointsComponentModeCommon::ParamaterNames::Rotation, rotation);
+                        editorJointRequest->SetVector3Value(PhysX::JointsComponentModeCommon::ParameterNames::Rotation, rotation);
                         editorJointRequest->SetLinearValuePair(
-                            PhysX::JointsComponentModeCommon::ParamaterNames::TwistLimits,
+                            PhysX::JointsComponentModeCommon::ParameterNames::TwistLimits,
                             PhysX::AngleLimitsFloatPair(limitUpper, limitLower));
                     });
                 followColliderEntity->Deactivate();
@@ -124,7 +124,7 @@ namespace ROS2
         PhysX::EditorJointRequestBus::Event(
             AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
             &PhysX::EditorJointRequests::SetEntityIdValue,
-            PhysX::JointsComponentModeCommon::ParamaterNames::LeadEntity,
+            PhysX::JointsComponentModeCommon::ParameterNames::LeadEntity,
             leadColliderEntityId);
         followColliderEntity->Deactivate();
         return AZ::Success(jointComponent->GetId());

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -33,7 +33,8 @@ namespace ROS2::Utils
 
     AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC()
     {
-        const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj" };
+        const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj", ".fbx" };
+        const AZStd::string kAzModelExtension(".azmodel");
         AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets;
 
         // take all meshes in catalog
@@ -42,7 +43,7 @@ namespace ROS2::Utils
         {
             if (AZ::Data::AssetManager::Instance().GetHandler(info.m_assetType))
             {
-                if (!info.m_relativePath.ends_with(".azmodel"))
+                if (!info.m_relativePath.ends_with(kAzModelExtension))
                 {
                     return;
                 }
@@ -78,7 +79,19 @@ namespace ROS2::Utils
                 t.m_assetId = info.m_assetId;
                 t.m_sourceAssetGlobalPath = fullSourcePathStr;
                 t.m_productAssetRelativePath = info.m_relativePath;
-                availableAssets[crc] = t;
+                if (availableAssets.contains(crc))
+                {
+                    const AZStd::string stem(fullSourcePath.Stem().Native());
+                    // probably there is already submesh added. Replace only if there is exact name
+                    if (info.m_relativePath.contains(stem + kAzModelExtension))
+                    {
+                        availableAssets[crc] = t;
+                    }
+                }
+                else
+                {
+                    availableAssets[crc] = t;
+                }
             }
         };
         AZ::Data::AssetCatalogRequestBus::Broadcast(

--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -187,7 +187,12 @@ namespace XR
 
     AZ::u32 System::GetNumViews() const
     {
-        return m_swapChain->GetNumViews();
+        if (m_swapChain)
+        {
+            return m_swapChain->GetNumViews();
+        }
+        AZ_Warning("XRSystem", false, "SwapChain is null");
+        return 0;
     }
 
     AZ::u32 System::GetCurrentImageIndex(AZ::u32 viewIndex) const
@@ -198,7 +203,7 @@ namespace XR
 
     bool System::ShouldRender() const
     {
-        if (m_session->IsSessionRunning())
+        if (m_session && m_session->IsSessionRunning())
         { 
             return m_device->ShouldRender();
         }

--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -191,6 +191,7 @@ namespace XR
         {
             return m_swapChain->GetNumViews();
         }
+
         AZ_Warning("XRSystem", false, "SwapChain is null");
         return 0;
     }

--- a/Templates/Multiplayer/template.json
+++ b/Templates/Multiplayer/template.json
@@ -1062,6 +1062,10 @@
             "isTemplated": true
         },
         {
+            "file": "Prefabs/NetworkRigidBodyCube.prefab",
+            "isTemplated": true
+        },
+        {
             "file": "Prefabs/Player.prefab",
             "isTemplated": true
         },


### PR DESCRIPTION
It prevents choosing sub-mesh in a situation when the Asset processor has created more than one product asset from the source asset. Enables fbx in URDF importer.
