### PR TITLE
Made ROS2Frame required for ROS2Odometry to prevent possible crash on…

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -110,8 +110,6 @@ namespace ROS2
         //! the imperfections arising due to various physical factors e.g. fluctuations in rotary motion of the lidar (angular noise) or
         //! distance accuracy (distance noise).
         //! For the the details about Gaussian noise, please refer to https://en.wikipedia.org/wiki/Gaussian_noise.
-        //! You can also check-out the RobotecGPULidar (integrated in the RobotecGPULidar Gem) docs concerning these types of lidar noise at
-        //! https://github.com/RobotecAI/RobotecGPULidar/blob/v11/docs/GaussianNoise.md.
         //! @param angularNoiseStdDev Angular noise standard deviation.
         //! @param distanceNoiseStdDevBase Base value for Distance noise standard deviation.
         //! @param distanceNoiseStdDevRisePerMeter Value by which the distance noise standard deviation increases per meter length from

--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
@@ -51,6 +51,7 @@ namespace ROS2
     void ROS2OdometrySensorComponent::FrequencyTick()
     {
         auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
+        AZ_Assert(ros2Frame, "ROS2Frame must be present for ROS2OdometrySensorComponent");
         auto transform = ros2Frame->GetFrameTransform();
 
         AZ::Vector3 linearVelocity;
@@ -74,6 +75,7 @@ namespace ROS2
     void ROS2OdometrySensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
     }
 
     void ROS2OdometrySensorComponent::Activate()


### PR DESCRIPTION
Added ROS2Frame as required service for ROS2OdometrySensor.
Added Assert after getting component to prevent segfault without indication to cause. 