### PR TITLE
refactor ROS2SpawnerComponent

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBus.h
@@ -11,6 +11,7 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <ROS2/Spawner/SpawnerInfo.h>
 
 namespace ROS2
 {
@@ -28,8 +29,9 @@ namespace ROS2
         //! @return default spawn point coordinates set by user in Editor (by default: translation: {0, 0, 0}, rotation: {0, 0, 0, 1},
         //! scale: 1.0)
         virtual const AZ::Transform& GetDefaultSpawnPose() const = 0;
+
+        virtual AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetAllSpawnPointInfos() const = 0;
     };
 
     using SpawnerRequestsBus = AZ::EBus<SpawnerRequests>;
-    using SpawnerInterface = AZ::Interface<SpawnerRequests>;
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerInfo.h
+++ b/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerInfo.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2
+{
+    struct SpawnPointInfo
+    {
+        AZStd::string info;
+        AZ::Transform pose;
+    };
+
+    using SpawnPointInfoMap = AZStd::unordered_map<AZStd::string, SpawnPointInfo>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
+++ b/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
@@ -5,11 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <Lidar/LidarRegistrarEditorSystemComponent.h>
 #include <ROS2EditorSystemComponent.h>
 #include <ROS2ModuleInterface.h>
-#include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <RobotImporter/ROS2RobotImporterEditorSystemComponent.h>
+#include <Spawner/ROS2SpawnPointEditorComponent.h>
+#include <Spawner/ROS2SpawnerEditorComponent.h>
 
 #include <QtCore/qglobal.h>
 
@@ -30,19 +32,19 @@ namespace ROS2
         ROS2EditorModule()
         {
             InitROS2Resources();
-            
+
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
             // This will associate the AzTypeInfo information for the components with the SerializeContext, BehaviorContext and
             // EditContext. This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(
                 m_descriptors.end(),
-                {
-                    ROS2EditorSystemComponent::CreateDescriptor(),
-                    LidarRegistrarEditorSystemComponent::CreateDescriptor(),
-                    ROS2RobotImporterEditorSystemComponent::CreateDescriptor(),
-                    ROS2CameraSensorEditorComponent::CreateDescriptor(),
-                });
+                { ROS2EditorSystemComponent::CreateDescriptor(),
+                  LidarRegistrarEditorSystemComponent::CreateDescriptor(),
+                  ROS2RobotImporterEditorSystemComponent::CreateDescriptor(),
+                  ROS2CameraSensorEditorComponent::CreateDescriptor(),
+                  ROS2SpawnerEditorComponent::CreateDescriptor(),
+                  ROS2SpawnPointEditorComponent::CreateDescriptor() });
         }
 
         /**

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include "ROS2/Spawner/SpawnerInfo.h"
+#include <AzCore/Component/Entity.h>
+#include <qcombobox.h>
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/string/string.h>
@@ -34,6 +37,7 @@ namespace ROS2
         void setSuccess(bool success);
         bool isComplete() const override;
         bool IsUseArticulations() const;
+        AZStd::optional<AZ::Transform> getSelectedSpawnPoint() const;
     Q_SIGNALS:
         void onCreateButtonPressed();
 
@@ -43,6 +47,8 @@ namespace ROS2
         QPushButton* m_createButton;
         QTextEdit* m_log;
         QCheckBox* m_useArticulation;
+        QComboBox* m_spawnPointsComboBox;
+        AZStd::vector<SpawnPointInfoMap> m_spawnPointsInfos;
         RobotImporterWidget* m_parentImporterWidget;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -356,7 +356,12 @@ namespace ROS2
         }
         const bool useArticulation = m_prefabMakerPage->IsUseArticulations();
         m_prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
-            m_urdfPath.String(), m_parsedUrdf, prefabPath.String(), m_urdfAssetsMapping, useArticulation);
+            m_urdfPath.String(),
+            m_parsedUrdf,
+            prefabPath.String(),
+            m_urdfAssetsMapping,
+            useArticulation,
+            m_prefabMakerPage->getSelectedSpawnPoint());
 
         auto prefabOutcome = m_prefabMaker->CreatePrefabFromURDF();
         if (prefabOutcome.IsSuccess())

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
@@ -100,7 +100,7 @@ namespace ROS2
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         AZ_Assert(entity, "No entity for id %s", entityId.ToString().c_str());
 
-        AZ_TracePrintf("ArticulationsMaker", "Processing inertial for entity id: %s\n", entityId.ToString().c_str());
+        AZ_Trace("ArticulationsMaker", "Processing inertial for entity id: %s\n", entityId.ToString().c_str());
         PhysX::EditorArticulationLinkConfiguration articulationLinkConfiguration;
 
         articulationLinkConfiguration = AddToArticulationConfig(articulationLinkConfiguration, link->inertial);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -58,7 +58,7 @@ namespace ROS2
         {
             m_wheelMaterial =
                 AZ::Data::Asset<Physics::MaterialAsset>(assetId, Physics::MaterialAsset::TYPEINFO_Uuid(), physicsMaterialAssetRelPath);
-            AZ_TracePrintf(Internal::CollidersMakerLoggingTag, "Waiting for asset load\n");
+            AZ_Trace(Internal::CollidersMakerLoggingTag, "Waiting for asset load\n");
             m_wheelMaterial.BlockUntilLoadComplete();
         }
         else
@@ -150,7 +150,7 @@ namespace ROS2
 
             if (result.GetResult() != AZ::SceneAPI::Events::ProcessingResult::Success)
             {
-                AZ_TracePrintf(Internal::CollidersMakerLoggingTag, "Scene updated\n");
+                AZ_Trace(Internal::CollidersMakerLoggingTag, "Scene updated\n");
                 return;
             }
 
@@ -242,7 +242,7 @@ namespace ROS2
         { // it is ok not to have collision in a link
             return;
         }
-        AZ_TracePrintf(Internal::CollidersMakerLoggingTag, "Processing collisions for entity id:%s\n", entityId.ToString().c_str());
+        AZ_Trace(Internal::CollidersMakerLoggingTag, "Processing collisions for entity id:%s\n", entityId.ToString().c_str());
 
         auto geometry = collision->geometry;
         if (!geometry)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -21,7 +21,7 @@ namespace ROS2
         { // it is ok not to have inertia in a link
             return;
         }
-        AZ_TracePrintf("AddInertial", "Processing inertial for entity id: %s\n", entityId.ToString().c_str());
+        AZ_Trace("AddInertial", "Processing inertial for entity id: %s\n", entityId.ToString().c_str());
 
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         PhysX::EditorRigidBodyConfiguration rigidBodyConfiguration;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
@@ -79,7 +79,7 @@ namespace ROS2::PrefabMakerUtils
             return AZ::Failure(AZStd::string("Invalid id for created entity"));
         }
 
-        AZ_TracePrintf("CreateEntity", "Processing entity id: %s with name: %s\n", entityId.ToString().c_str(), name.c_str());
+        AZ_Trace("CreateEntity", "Processing entity id: %s with name: %s\n", entityId.ToString().c_str(), name.c_str());
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         entity->SetName(name);
         entity->Deactivate();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -12,6 +12,7 @@
 #include <API/EditorAssetSystemAPI.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/IO/FileIO.h>
+#include <AzCore/Math/Transform.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
@@ -19,9 +20,9 @@
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2GemUtilities.h>
-#include <ROS2/Spawner/SpawnerBus.h>
 #include <RobotControl/ROS2RobotControlComponent.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
+#include <optional>
 
 namespace ROS2
 {
@@ -30,12 +31,14 @@ namespace ROS2
         urdf::ModelInterfaceSharedPtr model,
         AZStd::string prefabPath,
         const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
-        bool useArticulations)
+        bool useArticulations,
+        const AZStd::optional<AZ::Transform> spawnPosition)
         : m_model(model)
         , m_visualsMaker(model->materials_, urdfAssetsMapping)
         , m_collidersMaker(urdfAssetsMapping)
         , m_prefabPath(std::move(prefabPath))
         , m_urdfAssetsMapping(urdfAssetsMapping)
+        , m_spawnPosition(spawnPosition)
         , m_useArticulations(useArticulations)
     {
         AZ_Assert(!m_prefabPath.empty(), "Prefab path is empty");
@@ -92,7 +95,7 @@ namespace ROS2
 
         for (const auto& [name, result] : createdLinks)
         {
-            AZ_TracePrintf(
+            AZ_Trace(
                 "CreatePrefabFromURDF",
                 "Link with name %s was created as: %s\n",
                 name.c_str(),
@@ -121,7 +124,7 @@ namespace ROS2
                     auto* transformInterface = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
                     if (transformInterface)
                     {
-                        AZ_TracePrintf(
+                        AZ_Trace(
                             "CreatePrefabFromURDF",
                             "Setting transform %s %s to [%f %f %f] [%f %f %f %f]\n",
                             name.c_str(),
@@ -137,8 +140,7 @@ namespace ROS2
                     }
                     else
                     {
-                        AZ_TracePrintf(
-                            "CreatePrefabFromURDF", "Setting transform failed: %s does not have transform interface\n", name.c_str());
+                        AZ_Trace("CreatePrefabFromURDF", "Setting transform failed: %s does not have transform interface\n", name.c_str());
                     }
                 }
             }
@@ -150,71 +152,74 @@ namespace ROS2
             const auto thisEntry = createdLinks.at(name);
             if (!thisEntry.IsSuccess())
             {
-                AZ_TracePrintf("CreatePrefabFromURDF", "Link %s creation failed\n", name.c_str());
+                AZ_Trace("CreatePrefabFromURDF", "Link %s creation failed\n", name.c_str());
                 continue;
             }
             auto parentPtr = linkPtr->getParent();
             if (!parentPtr)
             {
-                AZ_TracePrintf("CreatePrefabFromURDF", "Link %s has no parents\n", name.c_str());
+                AZ_Trace("CreatePrefabFromURDF", "Link %s has no parents\n", name.c_str());
                 continue;
             }
             AZStd::string parentName(parentPtr->name.c_str(), parentPtr->name.size());
             const auto parentEntry = createdLinks.find(parentName);
             if (parentEntry == createdLinks.end())
             {
-                AZ_TracePrintf("CreatePrefabFromURDF", "Link %s has invalid parent name %s\n", name.c_str(), parentName.c_str());
+                AZ_Trace("CreatePrefabFromURDF", "Link %s has invalid parent name %s\n", name.c_str(), parentName.c_str());
                 continue;
             }
             if (!parentEntry->second.IsSuccess())
             {
-                AZ_TracePrintf(
-                    "CreatePrefabFromURDF", "Link %s has parent %s which has failed to create\n", name.c_str(), parentName.c_str());
+                AZ_Trace("CreatePrefabFromURDF", "Link %s has parent %s which has failed to create\n", name.c_str(), parentName.c_str());
                 continue;
             }
-            AZ_TracePrintf(
+            AZ_Trace(
                 "CreatePrefabFromURDF",
                 "Link %s setting parent to %s\n",
                 thisEntry.GetValue().ToString().c_str(),
                 parentEntry->second.GetValue().ToString().c_str());
-            AZ_TracePrintf("CreatePrefabFromURDF", "Link %s setting parent to %s\n", name.c_str(), parentName.c_str());
+            AZ_Trace("CreatePrefabFromURDF", "Link %s setting parent to %s\n", name.c_str(), parentName.c_str());
             auto* entity = AzToolsFramework::GetEntityById(thisEntry.GetValue());
             entity->Activate();
             AZ::TransformBus::Event(thisEntry.GetValue(), &AZ::TransformBus::Events::SetParent, parentEntry->second.GetValue());
             entity->Deactivate();
         }
 
-        if (!m_useArticulations)
+        auto joints = Utils::GetAllJoints(m_model->root_link_->child_links);
+        for (const auto& [name, jointPtr] : joints)
         {
-            auto joints = Utils::GetAllJoints(m_model->root_link_->child_links);
-            for (const auto& [name, jointPtr] : joints)
+            AZ_Assert(jointPtr, "joint %s is null", name.c_str());
+            AZ_Trace(
+                "CreatePrefabFromURDF",
+                "Creating joint %s : %s -> %s\n",
+                name.c_str(),
+                jointPtr->parent_link_name.c_str(),
+                jointPtr->child_link_name.c_str());
+            auto leadEntity = createdLinks.at(jointPtr->parent_link_name.c_str());
+            auto childEntity = createdLinks.at(jointPtr->child_link_name.c_str());
+            AZ::Entity* childEntityPtr = AzToolsFramework::GetEntityById(childEntity.GetValue());
+            if (childEntityPtr)
             {
-                AZ_Assert(jointPtr, "joint %s is null", name.c_str());
-                AZ_TracePrintf(
-                    "CreatePrefabFromURDF",
-                    "Creating joint %s : %s -> %s\n",
-                    name.c_str(),
-                    jointPtr->parent_link_name.c_str(),
-                    jointPtr->child_link_name.c_str());
-
-                auto leadEntity = createdLinks.at(jointPtr->parent_link_name.c_str());
-                auto childEntity = createdLinks.at(jointPtr->child_link_name.c_str());
-                // check if both has RigidBody
-                if (leadEntity.IsSuccess() && childEntity.IsSuccess())
+                auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(childEntityPtr);
+                if (component)
                 {
-                    AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-                    auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
-                    m_status.emplace(
-                        name, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
+                    component->SetJointName(AZStd::string(name.c_str(), name.length()));
                 }
-                else
-                {
-                    AZ_Warning("CreatePrefabFromURDF", false, "cannot create joint %s", name.c_str());
-                }
+            }
+            // check if both has RigidBody and we are not creating articulation
+            if (!m_useArticulations && leadEntity.IsSuccess() && childEntity.IsSuccess())
+            {
+                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
+                m_status.emplace(name, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
+            }
+            else
+            {
+                AZ_Warning("CreatePrefabFromURDF", false, "cannot create joint %s", name.c_str());
             }
         }
 
-        MoveEntityToDefaultSpawnPoint(createEntityRoot.GetValue());
+        MoveEntityToDefaultSpawnPoint(createEntityRoot.GetValue(), m_spawnPosition);
 
         auto contentEntityId = createEntityRoot.GetValue();
         AddRobotControl(contentEntityId);
@@ -231,11 +236,11 @@ namespace ROS2
         AZ::IO::Path relativeFilePath = prefabLoaderInterface->GenerateRelativePath(m_prefabPath.c_str());
 
         const auto templateId = prefabSystemComponent->GetTemplateIdFromFilePath(relativeFilePath);
-        AZ_TracePrintf("CreatePrefabFromURDF", "GetTemplateIdFromFilePath  %s -> %d \n", m_prefabPath.c_str(), templateId);
+        AZ_Trace("CreatePrefabFromURDF", "GetTemplateIdFromFilePath  %s -> %d \n", m_prefabPath.c_str(), templateId);
 
         if (templateId != AzToolsFramework::Prefab::InvalidTemplateId)
         {
-            AZ_TracePrintf("CreatePrefabFromURDF", "Prefab was already loaded\n");
+            AZ_Trace("CreatePrefabFromURDF", "Prefab was already loaded\n");
             prefabSystemComponent->RemoveTemplate(templateId);
         }
 
@@ -245,7 +250,7 @@ namespace ROS2
             AZ::EntityId prefabContainerEntityId = outcome.GetValue();
             PrefabMakerUtils::AddRequiredComponentsToEntity(prefabContainerEntityId);
         }
-        AZ_TracePrintf("CreatePrefabFromURDF", "Successfully created prefab %s\n", m_prefabPath.c_str());
+        AZ_Trace("CreatePrefabFromURDF", "Successfully created prefab %s\n", m_prefabPath.c_str());
 
         // End undo batch labeled "Robot Importer prefab creation"
         if (currentUndoBatch != nullptr)
@@ -313,13 +318,13 @@ namespace ROS2
         return m_prefabPath;
     }
 
-    void URDFPrefabMaker::MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId)
+    void URDFPrefabMaker::MoveEntityToDefaultSpawnPoint(
+        const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition = AZStd::nullopt)
     {
-        auto spawner = ROS2::SpawnerInterface::Get();
-
-        if (spawner == nullptr)
+        if (!spawnPosition.has_value())
         {
-            AZ_TracePrintf("URDF Importer", "Spawner not found - creating entity in (0,0,0)\n") return;
+            AZ_Trace("URDF Importer", "SpawnPosition is null - spawning in Editors default position\n");
+            return;
         }
 
         auto entity_ = AzToolsFramework::GetEntityById(rootEntityId);
@@ -327,12 +332,11 @@ namespace ROS2
 
         if (transformInterface_ == nullptr)
         {
-            AZ_TracePrintf("URDF Importer", "TransformComponent not found in created entity\n") return;
+            AZ_Trace("URDF Importer", "TransformComponent not found in created entity\n") return;
         }
 
-        auto pose = spawner->GetDefaultSpawnPose();
-
-        transformInterface_->SetWorldTM(pose);
+        transformInterface_->SetWorldTM(*spawnPosition);
+        AZ_Trace("URDF Importer", "Successfully set spawn position\n")
     }
 
     AZStd::string URDFPrefabMaker::GetStatus()

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -15,12 +15,14 @@
 #include "UrdfParser.h"
 #include "VisualsMaker.h"
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Math/Transform.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <RobotImporter/Utils/SourceAssetsStorage.h>
+#include <optional>
 
 namespace ROS2
 {
@@ -39,7 +41,8 @@ namespace ROS2
             urdf::ModelInterfaceSharedPtr model,
             AZStd::string prefabPath,
             const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
-            bool useArticulations = false);
+            bool useArticulations = false,
+            AZStd::optional<AZ::Transform> spawnPosition = AZStd::nullopt);
 
         ~URDFPrefabMaker() = default;
 
@@ -59,7 +62,7 @@ namespace ROS2
         AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(urdf::LinkSharedPtr link, AZ::EntityId parentEntityId);
         void BuildAssetsForLink(urdf::LinkSharedPtr link);
         void AddRobotControl(AZ::EntityId rootEntityId);
-        static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId);
+        static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
         urdf::ModelInterfaceSharedPtr m_model;
         AZStd::string m_prefabPath;
@@ -74,5 +77,7 @@ namespace ROS2
 
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         bool m_useArticulations{ false };
+
+        const AZStd::optional<AZ::Transform> m_spawnPosition;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -67,7 +67,7 @@ namespace ROS2
             return;
         }
 
-        AZ_TracePrintf("AddVisual", "Processing visual for entity id:%s\n", entityId.ToString().c_str());
+        AZ_Trace("AddVisual", "Processing visual for entity id:%s\n", entityId.ToString().c_str());
 
         // Use a name generated from the link unless specific name is defined for this visual
         const char* subEntityName = visual->name.empty() ? generatedName.c_str() : visual->name.c_str();

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -476,7 +476,7 @@ namespace ROS2::Utils
 
         if (result.GetResult() != AZ::SceneAPI::Events::ProcessingResult::Success)
         {
-            AZ_TracePrintf("CreateSceneManifest", "Scene updated\n");
+            AZ_Trace("CreateSceneManifest", "Scene updated\n");
             return false;
         }
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ROS2SpawnPointComponent.h"
+#include "Spawner/ROS2SpawnPointComponentController.h"
 #include <AzCore/Component/Entity.h>
 
 #include <AzCore/Serialization/EditContext.h>
@@ -17,47 +18,34 @@
 
 namespace ROS2
 {
+    ROS2SpawnPointComponent::ROS2SpawnPointComponent(const ROS2SpawnPointComponentConfig& config)
+        : ROS2SpawnPointComponentBase(config)
+    {
+    }
+
     void ROS2SpawnPointComponent::Activate()
     {
+        ROS2SpawnPointComponentBase::Activate();
     }
 
     void ROS2SpawnPointComponent::Deactivate()
     {
+        ROS2SpawnPointComponentBase::Deactivate();
     }
 
     void ROS2SpawnPointComponent::Reflect(AZ::ReflectContext* context)
     {
+        ROS2SpawnPointComponentBase::Reflect(context);
+
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2SpawnPointComponent, AZ::Component>()
-                ->Version(1)
-                ->Field("Name", &ROS2SpawnPointComponent::m_name)
-                ->Field("Info", &ROS2SpawnPointComponent::m_info);
-
-            if (AZ::EditContext* ec = serialize->GetEditContext())
-            {
-                ec->Class<ROS2SpawnPointComponent>("ROS2 Spawn Point", "Spawn Point")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Stores information about available spawn point")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_name, "Name", "Name")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_info, "Info", "Spawn point detailed description");
-            }
+            serialize->Class<ROS2SpawnPointComponent, ROS2SpawnPointComponentBase>()->Version(1);
         }
     }
 
     AZStd::pair<AZStd::string, SpawnPointInfo> ROS2SpawnPointComponent::GetInfo() const
     {
-        auto transform_component = GetEntity()->FindComponent<AzFramework::TransformComponent>();
-
-        // if SpawnPointComponent entity for some reason does not include TransformComponent - this default pose will be returned
-        AZ::Transform transform = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1.0 }, 1.0 };
-
-        if (transform_component != nullptr)
-        {
-            transform = transform_component->GetWorldTM();
-        }
-        return { m_name, SpawnPointInfo{ m_info, transform } };
+        return m_controller.GetInfo();
     }
+
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponent.h
@@ -7,37 +7,36 @@
  */
 #pragma once
 
+#include "Spawner/ROS2SpawnPointComponentController.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Transform.h>
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <ROS2/Spawner/SpawnerInfo.h>
 
 namespace ROS2
 {
-    struct SpawnPointInfo
-    {
-        AZStd::string info;
-        AZ::Transform pose;
-    };
+
+    using ROS2SpawnPointComponentBase =
+        AzFramework::Components::ComponentAdapter<ROS2SpawnPointComponentController, ROS2SpawnPointComponentConfig>;
 
     //! SpawnPoint indicates a place which is suitable to spawn a robot.
-    class ROS2SpawnPointComponent : public AZ::Component
+    class ROS2SpawnPointComponent : public ROS2SpawnPointComponentBase
     {
     public:
-        AZ_COMPONENT(ROS2SpawnPointComponent, "{2AE1CAAE-B300-49FD-8F6D-F7AAABED1EC3}", AZ::Component);
+        AZ_COMPONENT(ROS2SpawnPointComponent, "{422c0495-5bbf-4207-ac17-8e607c6d3b30}", AZ::Component);
 
         ROS2SpawnPointComponent() = default;
-
+        ROS2SpawnPointComponent(const ROS2SpawnPointComponentConfig& config);
         ~ROS2SpawnPointComponent() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
         //////////////////////////////////////////////////////////////////////////
-        // Component overrides
+        // ROS2SpawnPointComponentBase overrides
         void Activate() override;
         void Deactivate() override;
         //////////////////////////////////////////////////////////////////////////
-        static void Reflect(AZ::ReflectContext* context);
 
         AZStd::pair<AZStd::string, SpawnPointInfo> GetInfo() const;
-
-    private:
-        AZStd::string m_name;
-        AZStd::string m_info;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponentController.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "Spawner/ROS2SpawnPointComponentController.h"
+#include "Spawner/ROS2SpawnerComponentController.h"
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    void ROS2SpawnPointComponentConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ROS2SpawnPointComponentConfig, AZ::ComponentConfig>()
+                ->Version(1)
+                ->Field("Name", &ROS2SpawnPointComponentConfig::m_name)
+                ->Field("Info", &ROS2SpawnPointComponentConfig::m_info);
+
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext
+                    ->Class<ROS2SpawnPointComponentConfig>("ROS2SpawnPointComponentConfig", "Config for the ROS2 Spawn Point Component")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Stores information about available spawn point")
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponentConfig::m_name, "Name", "Name")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponentConfig::m_info, "Info", "Spawn point detailed description");
+            }
+        }
+    }
+
+    void ROS2SpawnPointComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2SpawnPointComponentConfig::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ROS2SpawnPointComponentController>()->Version(1)->Field(
+                "Configuration", &ROS2SpawnPointComponentController::m_config);
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext
+                    ->Class<ROS2SpawnPointComponentController>("ROS2SpawnPointController", "Controller for the ROS2 Spawn Point Component")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnPointComponentController::m_config);
+            }
+        }
+    }
+
+    ROS2SpawnPointComponentController::ROS2SpawnPointComponentController(const ROS2SpawnPointComponentConfig& config)
+    {
+        SetConfiguration(config);
+    }
+
+    void ROS2SpawnPointComponentController::SetConfiguration(const ROS2SpawnPointComponentConfig& config)
+    {
+        m_config = config;
+    }
+
+    const ROS2SpawnPointComponentConfig& ROS2SpawnPointComponentController::GetConfiguration() const
+    {
+        return m_config;
+    }
+
+    void ROS2SpawnPointComponentController::Activate(AZ::EntityId entityId)
+    {
+        m_config.m_editorEntityId = entityId;
+    }
+
+    void ROS2SpawnPointComponentController::Deactivate()
+    {
+    }
+
+    AZStd::pair<AZStd::string, SpawnPointInfo> ROS2SpawnPointComponentController::GetInfo() const
+    {
+        AZ::Transform transform = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1.0 }, 1.0 };
+        AZ::TransformBus::EventResult(transform, m_config.m_editorEntityId, &AZ::TransformBus::Events::GetWorldTM);
+
+        return { m_config.m_name, SpawnPointInfo{ m_config.m_info, transform } };
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointComponentController.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Transform.h>
+#include <ROS2/Spawner/SpawnerInfo.h>
+
+namespace ROS2
+{
+
+    class ROS2SpawnPointComponentConfig final : public AZ::ComponentConfig
+    {
+    public:
+        AZ_RTTI(ROS2SpawnPointComponentConfig, "{eb3e6937-0d1d-4a31-87d7-6d6663e3cf35}");
+
+        ROS2SpawnPointComponentConfig() = default;
+        ~ROS2SpawnPointComponentConfig() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZStd::string m_name;
+        AZStd::string m_info;
+
+        AZ::EntityId m_editorEntityId;
+    };
+
+    //! SpawnPoint indicates a place which is suitable to spawn a robot.
+    class ROS2SpawnPointComponentController
+    {
+    public:
+        AZ_TYPE_INFO(ROS2SpawnPointComponentController, "{cd29d626-0205-4ca0-ac0f-5377e4fd84dd}");
+
+        ROS2SpawnPointComponentController() = default;
+        explicit ROS2SpawnPointComponentController(const ROS2SpawnPointComponentConfig& config);
+        ~ROS2SpawnPointComponentController() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //////////////////////////////////////////////////////////////////////////
+        // Controller component
+        void Activate(AZ::EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const ROS2SpawnPointComponentConfig& config);
+        const ROS2SpawnPointComponentConfig& GetConfiguration() const;
+        //////////////////////////////////////////////////////////////////////////
+
+        AZStd::pair<AZStd::string, SpawnPointInfo> GetInfo() const;
+
+    private:
+        ROS2SpawnPointComponentConfig m_config;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointEditorComponent.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnPointEditorComponent.h"
+#include "Spawner/ROS2SpawnPointComponentController.h"
+#include "Spawner/ROS2SpawnerEditorComponent.h"
+
+namespace ROS2
+{
+    ROS2SpawnPointEditorComponent::ROS2SpawnPointEditorComponent(const ROS2SpawnPointComponentConfig& configuration)
+        : ROS2SpawnPointEditorComponentBase(configuration)
+    {
+    }
+
+    void ROS2SpawnPointEditorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2SpawnPointEditorComponentBase::Reflect(context);
+
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+
+        if (serializeContext)
+        {
+            serializeContext->Class<ROS2SpawnPointEditorComponent, ROS2SpawnPointEditorComponentBase>()->Version(1);
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<ROS2SpawnPointEditorComponent>("ROS2 Spawn Point", "Spawn point for robots")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+            }
+        }
+    }
+
+    void ROS2SpawnPointEditorComponent::Activate()
+    {
+        ROS2SpawnPointEditorComponentBase::Activate();
+    }
+
+    void ROS2SpawnPointEditorComponent::Deactivate()
+    {
+        ROS2SpawnPointEditorComponentBase::Deactivate();
+    }
+
+    AZStd::pair<AZStd::string, SpawnPointInfo> ROS2SpawnPointEditorComponent::GetInfo() const
+    {
+        return m_controller.GetInfo();
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnPointEditorComponent.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "Spawner/ROS2SpawnPointComponent.h"
+#include "Spawner/ROS2SpawnPointComponentController.h"
+#include "Spawner/ROS2SpawnerEditorComponent.h"
+#include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+
+namespace ROS2
+{
+    using ROS2SpawnPointEditorComponentBase = AzToolsFramework::Components::
+        EditorComponentAdapter<ROS2SpawnPointComponentController, ROS2SpawnPointComponent, ROS2SpawnPointComponentConfig>;
+
+    class ROS2SpawnPointEditorComponent : public ROS2SpawnPointEditorComponentBase
+    {
+    public:
+        AZ_EDITOR_COMPONENT(
+            ROS2SpawnPointEditorComponent, "{2AE1CAAE-B300-49FD-8F6D-F7AAABED1EC3}", AzToolsFramework::Components::EditorComponentBase);
+
+        ROS2SpawnPointEditorComponent() = default;
+        ROS2SpawnPointEditorComponent(const ROS2SpawnPointComponentConfig& config);
+        ~ROS2SpawnPointEditorComponent() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //////////////////////////////////////////////////////////////////////////
+        // ROS2SpawnPointEditorComponentBase overrides
+        void Activate() override;
+        void Deactivate() override;
+        //////////////////////////////////////////////////////////////////////////
+
+        AZStd::pair<AZStd::string, SpawnPointInfo> GetInfo() const;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -31,7 +31,7 @@ namespace ROS2
 
         const auto& ns = m_controller.GetNamespace();
 
-        m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
+        m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetModelList>(
             AZStd::string::format("%s/get_available_spawnable_names", ns.data()).data(),
             [this](const GetAvailableSpawnableNamesRequest& request, const GetAvailableSpawnableNamesResponse& response)
             {
@@ -52,7 +52,7 @@ namespace ROS2
                 GetSpawnPointInfo(request, response);
             });
 
-        m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
+        m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetModelList>(
             AZStd::string::format("%s/get_spawn_points_names", ns.data()).data(),
             [this](const GetSpawnPointsNamesRequest& request, const GetSpawnPointsNamesResponse& response)
             {

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -33,28 +33,28 @@ namespace ROS2
 
         m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
             AZStd::string::format("%s/get_available_spawnable_names", ns.data()).data(),
-            [this](const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
+            [this](const GetAvailableSpawnableNamesRequest& request, const GetAvailableSpawnableNamesResponse& response)
             {
                 GetAvailableSpawnableNames(request, response);
             });
 
         m_spawnService = ros2Node->create_service<gazebo_msgs::srv::SpawnEntity>(
             AZStd::string::format("%s/spawn_entity", ns.data()).data(),
-            [this](const SpawnEntityRequest request, SpawnEntityResponse response)
+            [this](const SpawnEntityRequest& request, const SpawnEntityResponse& response)
             {
                 SpawnEntity(request, response);
             });
 
         m_getSpawnPointInfoService = ros2Node->create_service<gazebo_msgs::srv::GetModelState>(
             AZStd::string::format("%s/get_spawn_point_info", ns.data()).data(),
-            [this](const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response)
+            [this](const GetSpawnPointInfoRequest& request, const GetSpawnPointInfoResponse& response)
             {
                 GetSpawnPointInfo(request, response);
             });
 
         m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
             AZStd::string::format("%s/get_spawn_points_names", ns.data()).data(),
-            [this](const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response)
+            [this](const GetSpawnPointsNamesRequest& request, const GetSpawnPointsNamesResponse& response)
             {
                 GetSpawnPointsNames(request, response);
             });
@@ -81,7 +81,7 @@ namespace ROS2
     }
 
     void ROS2SpawnerComponent::GetAvailableSpawnableNames(
-        const GetAvailableSpawnableNamesRequest& request, GetAvailableSpawnableNamesResponse response)
+        const GetAvailableSpawnableNamesRequest& request, const GetAvailableSpawnableNamesResponse& response)
     {
         for (const auto& [name, asset] : m_controller.GetSpawnables())
         {
@@ -90,7 +90,7 @@ namespace ROS2
         response->success = true;
     }
 
-    void ROS2SpawnerComponent::SpawnEntity(const SpawnEntityRequest& request, SpawnEntityResponse response)
+    void ROS2SpawnerComponent::SpawnEntity(const SpawnEntityRequest& request, const SpawnEntityResponse& response)
     {
         AZStd::string spawnableName(request->name.c_str());
         AZStd::string spawnPointName(request->xml.c_str(), request->xml.size());
@@ -173,7 +173,7 @@ namespace ROS2
     }
 
     void ROS2SpawnerComponent::GetSpawnPointsNames(
-        const ROS2::GetSpawnPointsNamesRequest& request, ROS2::GetSpawnPointsNamesResponse response)
+        const ROS2::GetSpawnPointsNamesRequest& request, const ROS2::GetSpawnPointsNamesResponse& response)
     {
         for (const auto& [name, info] : GetSpawnPoints())
         {
@@ -182,7 +182,7 @@ namespace ROS2
         response->success = true;
     }
 
-    void ROS2SpawnerComponent::GetSpawnPointInfo(const ROS2::GetSpawnPointInfoRequest& request, ROS2::GetSpawnPointInfoResponse response)
+    void ROS2SpawnerComponent::GetSpawnPointInfo(const ROS2::GetSpawnPointInfoRequest& request, const ROS2::GetSpawnPointInfoResponse& response)
     {
         const AZStd::string_view key(request->model_name.c_str(), request->model_name.size());
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -66,7 +66,9 @@ namespace ROS2
             AzFramework::EntitySpawnTicket::Id,
             AzFramework::SpawnableEntityContainerView,
             const AZ::Transform&,
-            const AZStd::string& spawnableName);
+            const AZStd::string& spawnableName,
+            const AZStd::string& customizedName
+            );
 
         void GetSpawnPointsNames(const GetSpawnPointsNamesRequest& request, const GetSpawnPointsNamesResponse& response);
         void GetSpawnPointInfo(const GetSpawnPointInfoRequest& request, const GetSpawnPointInfoResponse& response);

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -23,14 +23,14 @@
 
 namespace ROS2
 {
-    using GetAvailableSpawnableNamesRequest = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Request>;
-    using GetAvailableSpawnableNamesResponse = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Response>;
-    using SpawnEntityRequest = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Request>;
-    using SpawnEntityResponse = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Response>;
-    using GetSpawnPointInfoRequest = std::shared_ptr<gazebo_msgs::srv::GetModelState::Request>;
-    using GetSpawnPointInfoResponse = std::shared_ptr<gazebo_msgs::srv::GetModelState::Response>;
-    using GetSpawnPointsNamesRequest = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Request>;
-    using GetSpawnPointsNamesResponse = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Response>;
+    using GetAvailableSpawnableNamesRequest = gazebo_msgs::srv::GetWorldProperties::Request::ConstSharedPtr;
+    using GetAvailableSpawnableNamesResponse = gazebo_msgs::srv::GetWorldProperties::Response::SharedPtr;
+    using SpawnEntityRequest = gazebo_msgs::srv::SpawnEntity::Request::ConstSharedPtr;
+    using SpawnEntityResponse = gazebo_msgs::srv::SpawnEntity::Response::SharedPtr;
+    using GetSpawnPointInfoRequest = gazebo_msgs::srv::GetModelState::Request::ConstSharedPtr;
+    using GetSpawnPointInfoResponse = gazebo_msgs::srv::GetModelState::Response::SharedPtr;
+    using GetSpawnPointsNamesRequest = gazebo_msgs::srv::GetWorldProperties::Request::ConstSharedPtr;
+    using GetSpawnPointsNamesResponse = gazebo_msgs::srv::GetWorldProperties::Response::SharedPtr;
 
     using ROS2SpawnerComponentBase = AzFramework::Components::ComponentAdapter<ROS2SpawnerComponentController, ROS2SpawnerComponentConfig>;
     //! Manages robots spawning.
@@ -60,17 +60,16 @@ namespace ROS2
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
         rclcpp::Service<gazebo_msgs::srv::GetModelState>::SharedPtr m_getSpawnPointInfoService;
 
-        void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest& request, GetAvailableSpawnableNamesResponse response);
-        void SpawnEntity(const SpawnEntityRequest& request, SpawnEntityResponse response);
-
+        void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest& request, const GetAvailableSpawnableNamesResponse& response);
+        void SpawnEntity(const SpawnEntityRequest& request, const SpawnEntityResponse& response);
         void PreSpawn(
             AzFramework::EntitySpawnTicket::Id,
             AzFramework::SpawnableEntityContainerView,
             const AZ::Transform&,
             const AZStd::string& spawnableName);
 
-        void GetSpawnPointsNames(const GetSpawnPointsNamesRequest& request, GetSpawnPointsNamesResponse response);
-        void GetSpawnPointInfo(const GetSpawnPointInfoRequest& request, GetSpawnPointInfoResponse response);
+        void GetSpawnPointsNames(const GetSpawnPointsNamesRequest& request, const GetSpawnPointsNamesResponse& response);
+        void GetSpawnPointInfo(const GetSpawnPointInfoRequest& request, const GetSpawnPointInfoResponse& response);
 
         AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetSpawnPoints();
     };

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -17,20 +17,20 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <gazebo_msgs/srv/get_model_state.hpp>
-#include <gazebo_msgs/srv/get_world_properties.hpp>
+#include <gazebo_msgs/srv/get_model_list.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace ROS2
 {
-    using GetAvailableSpawnableNamesRequest = gazebo_msgs::srv::GetWorldProperties::Request::ConstSharedPtr;
-    using GetAvailableSpawnableNamesResponse = gazebo_msgs::srv::GetWorldProperties::Response::SharedPtr;
+    using GetAvailableSpawnableNamesRequest = gazebo_msgs::srv::GetModelList::Request::ConstSharedPtr;
+    using GetAvailableSpawnableNamesResponse = gazebo_msgs::srv::GetModelList::Response::SharedPtr;
     using SpawnEntityRequest = gazebo_msgs::srv::SpawnEntity::Request::ConstSharedPtr;
     using SpawnEntityResponse = gazebo_msgs::srv::SpawnEntity::Response::SharedPtr;
     using GetSpawnPointInfoRequest = gazebo_msgs::srv::GetModelState::Request::ConstSharedPtr;
     using GetSpawnPointInfoResponse = gazebo_msgs::srv::GetModelState::Response::SharedPtr;
-    using GetSpawnPointsNamesRequest = gazebo_msgs::srv::GetWorldProperties::Request::ConstSharedPtr;
-    using GetSpawnPointsNamesResponse = gazebo_msgs::srv::GetWorldProperties::Response::SharedPtr;
+    using GetSpawnPointsNamesRequest = gazebo_msgs::srv::GetModelList::Request::ConstSharedPtr;
+    using GetSpawnPointsNamesResponse = gazebo_msgs::srv::GetModelList::Response::SharedPtr;
 
     using ROS2SpawnerComponentBase = AzFramework::Components::ComponentAdapter<ROS2SpawnerComponentController, ROS2SpawnerComponentConfig>;
     //! Manages robots spawning.
@@ -55,8 +55,8 @@ namespace ROS2
         int m_counter = 1;
         AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
-        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnablesNamesService;
-        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnPointsNamesService;
+        rclcpp::Service<gazebo_msgs::srv::GetModelList>::SharedPtr m_getSpawnablesNamesService;
+        rclcpp::Service<gazebo_msgs::srv::GetModelList>::SharedPtr m_getSpawnPointsNamesService;
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
         rclcpp::Service<gazebo_msgs::srv::GetModelState>::SharedPtr m_getSpawnPointInfoService;
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -60,16 +60,17 @@ namespace ROS2
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
         rclcpp::Service<gazebo_msgs::srv::GetModelState>::SharedPtr m_getSpawnPointInfoService;
 
-        void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
-        void SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response);
+        void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest& request, GetAvailableSpawnableNamesResponse response);
+        void SpawnEntity(const SpawnEntityRequest& request, SpawnEntityResponse response);
+
         void PreSpawn(
             AzFramework::EntitySpawnTicket::Id,
             AzFramework::SpawnableEntityContainerView,
             const AZ::Transform&,
             const AZStd::string& spawnableName);
 
-        void GetSpawnPointsNames(const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response);
-        void GetSpawnPointInfo(const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response);
+        void GetSpawnPointsNames(const GetSpawnPointsNamesRequest& request, GetSpawnPointsNamesResponse response);
+        void GetSpawnPointInfo(const GetSpawnPointInfoRequest& request, GetSpawnPointInfoResponse response);
 
         AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetSpawnPoints();
     };

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnerComponentController.h"
+#include "Spawner/ROS2SpawnPointComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <ROS2/Spawner/SpawnerInfo.h>
+
+namespace ROS2
+{
+    void ROS2SpawnerComponentConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ROS2SpawnerComponentConfig, AZ::ComponentConfig>()
+                ->Version(1)
+                ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
+                ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
+                ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose);
+
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<ROS2SpawnerComponentConfig>("ROS2SpawnerComponentConfig", "Config for ROS2SpawnerComponent")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_spawnables, "Spawnables", "Spawnables")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2SpawnerComponentConfig::m_defaultSpawnPose,
+                        "Default spawn pose",
+                        "Default spawn pose");
+            }
+        }
+    }
+
+    AZ::EntityId ROS2SpawnerComponentController::GetEditorEntityId() const
+    {
+        return m_config.m_editorEntityId;
+    }
+
+    AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> ROS2SpawnerComponentController::GetSpawnables() const
+    {
+        return m_config.m_spawnables;
+    }
+
+    const AZ::Transform& ROS2SpawnerComponentController::GetDefaultSpawnPose() const
+    {
+        return m_config.m_defaultSpawnPose;
+    }
+
+    AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerComponentController::GetAllSpawnPointInfos() const
+    {
+        return GetSpawnPoints();
+    }
+
+    void ROS2SpawnerComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2SpawnerComponentConfig::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ROS2SpawnerComponentController>()->Version(1)->Field(
+                "Configuration", &ROS2SpawnerComponentController::m_config);
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<ROS2SpawnerComponentController>("ROS2SpawnerComponentController", "Controller for ROS2SpawnerComponent")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Manages spawning of robots in configurable locations")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentController::m_config);
+            }
+        }
+    }
+
+    AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerComponentController::GetSpawnPoints() const
+    {
+        AZStd::vector<AZ::EntityId> children;
+        AZ::TransformBus::EventResult(children, m_config.m_editorEntityId, &AZ::TransformBus::Events::GetChildren);
+
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
+
+        for (const AZ::EntityId& child : children)
+        {
+            AZ::Entity* childEntity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(childEntity, &AZ::ComponentApplicationRequests::FindEntity, child);
+            AZ_Assert(childEntity, "No child entity found for entity %s", child.ToString().c_str());
+
+            if (const auto* spawnPoint = childEntity->FindComponent<ROS2SpawnPointComponent>(); spawnPoint != nullptr)
+            {
+                result.insert(spawnPoint->GetInfo());
+            }
+        }
+
+        // setting name of spawn point component "default" in a child entity will have no effect since it is overwritten here with the
+        // default spawn pose of spawner
+        result["default"] = SpawnPointInfo{ "Default spawn pose defined in the Editor", m_config.m_defaultSpawnPose };
+        return result;
+    }
+
+    void ROS2SpawnerComponentController::Init()
+    {
+    }
+
+    void ROS2SpawnerComponentController::Activate(AZ::EntityId entityId)
+    {
+        m_config.m_editorEntityId = entityId;
+        SpawnerRequestsBus::Handler::BusConnect(entityId);
+    }
+
+    void ROS2SpawnerComponentController::Deactivate()
+    {
+        SpawnerRequestsBus::Handler::BusDisconnect();
+    }
+
+    ROS2SpawnerComponentController::ROS2SpawnerComponentController(const ROS2SpawnerComponentConfig& config)
+    {
+        SetConfiguration(config);
+    }
+
+    void ROS2SpawnerComponentController::SetConfiguration(const ROS2SpawnerComponentConfig& config)
+    {
+        m_config = config;
+    }
+
+    const ROS2SpawnerComponentConfig& ROS2SpawnerComponentController::GetConfiguration() const
+    {
+        return m_config;
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -24,10 +24,11 @@ namespace ROS2
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ROS2SpawnerComponentConfig, AZ::ComponentConfig>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
                 ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
-                ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose);
+                ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose)
+                ->Field("Namespace", &ROS2SpawnerComponentConfig::m_namespace);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
@@ -37,8 +38,13 @@ namespace ROS2
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2SpawnerComponentConfig::m_defaultSpawnPose,
-                        "Default spawn pose",
-                        "Default spawn pose");
+                        "Default Spawn Pose",
+                        "Default spawn pose")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2SpawnerComponentConfig::m_namespace,
+                        "Namespace",
+                        "Namespace for provided services. Global if empty");
             }
         }
     }
@@ -56,6 +62,11 @@ namespace ROS2
     const AZ::Transform& ROS2SpawnerComponentController::GetDefaultSpawnPose() const
     {
         return m_config.m_defaultSpawnPose;
+    }
+
+    const AZStd::string& ROS2SpawnerComponentController::GetNamespace() const
+    {
+        return m_config.m_namespace;
     }
 
     AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerComponentController::GetAllSpawnPointInfos() const

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ROS2/Spawner/SpawnerBus.h"
+#include "ROS2SpawnPointComponent.h"
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/base.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+
+namespace ROS2
+{
+    class ROS2SpawnerComponentConfig final : public AZ::ComponentConfig
+    {
+    public:
+        AZ_RTTI(ROS2SpawnerComponentConfig, "{ee71f892-006a-11ee-be56-0242ac120002}");
+
+        ROS2SpawnerComponentConfig() = default;
+        ~ROS2SpawnerComponentConfig() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::EntityId m_editorEntityId;
+        AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
+
+        AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
+    };
+
+    class ROS2SpawnerComponentController : public SpawnerRequestsBus::Handler
+    {
+    public:
+        AZ_TYPE_INFO(ROS2SpawnerComponentController, "{1e9e040c-006b-11ee-be56-0242ac120002}");
+        ROS2SpawnerComponentController() = default;
+        explicit ROS2SpawnerComponentController(const ROS2SpawnerComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //////////////////////////////////////////////////////////////////////////
+        // Controller component
+        void Init();
+        void Activate(AZ::EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const ROS2SpawnerComponentConfig& config);
+        const ROS2SpawnerComponentConfig& GetConfiguration() const;
+        //////////////////////////////////////////////////////////////////////////
+
+        //////////////////////////////////////////////////////////////////////////
+        // SpawnerRequestsBus::Handler overrides
+        const AZ::Transform& GetDefaultSpawnPose() const override;
+        SpawnPointInfoMap GetAllSpawnPointInfos() const override;
+        //////////////////////////////////////////////////////////////////////////
+
+        SpawnPointInfoMap GetSpawnPoints() const;
+        AZ::EntityId GetEditorEntityId() const;
+        AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;
+
+    private:
+        ROS2SpawnerComponentConfig m_config;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -31,6 +31,7 @@ namespace ROS2
 
         AZ::EntityId m_editorEntityId;
         AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
+        AZStd::string m_namespace;
 
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
     };
@@ -62,6 +63,7 @@ namespace ROS2
         SpawnPointInfoMap GetSpawnPoints() const;
         AZ::EntityId GetEditorEntityId() const;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;
+        const AZStd::string& GetNamespace() const;
 
     private:
         ROS2SpawnerComponentConfig m_config;

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnerEditorComponent.h"
+#include "AzCore/Debug/Trace.h"
+#include "ROS2SpawnPointEditorComponent.h"
+#include "Spawner/ROS2SpawnerComponentController.h"
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <ROS2/Spawner/SpawnerBus.h>
+
+namespace ROS2
+{
+    ROS2SpawnerEditorComponent::ROS2SpawnerEditorComponent(const ROS2SpawnerComponentConfig& configuration)
+        : ROS2SpawnerEditorComponentBase(configuration)
+    {
+    }
+
+    void ROS2SpawnerEditorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2SpawnerEditorComponentBase::Reflect(context);
+
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<ROS2SpawnerEditorComponent, ROS2SpawnerEditorComponentBase>()->Version(1);
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<ROS2SpawnerEditorComponent>("ROS2 Spawner", "Spawner component")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Manages spawning of robots in configurable locations")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+            }
+        }
+    }
+
+    AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerEditorComponent::GetSpawnPoints() const
+    {
+        AZStd::vector<AZ::EntityId> children;
+        AZ::TransformBus::EventResult(children, m_controller.GetEditorEntityId(), &AZ::TransformBus::Events::GetChildren);
+
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
+
+        for (const AZ::EntityId& child : children)
+        {
+            AZ::Entity* childEntity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(childEntity, &AZ::ComponentApplicationRequests::FindEntity, child);
+            AZ_Assert(childEntity, "No child entity found for entity %s", child.ToString().c_str());
+
+            const auto* editorSpawnPoint = childEntity->FindComponent<ROS2SpawnPointEditorComponent>();
+
+            if (editorSpawnPoint != nullptr)
+            {
+                result.insert(editorSpawnPoint->GetInfo());
+            }
+        }
+
+        // setting name of spawn point component "default" in a child entity will have no effect since it is overwritten here with the
+        // default spawn pose of spawner
+        result["default"] = SpawnPointInfo{ "Default spawn pose defined in the Editor", m_controller.GetDefaultSpawnPose() };
+        return result;
+    }
+
+    const AZ::Transform& ROS2SpawnerEditorComponent::GetDefaultSpawnPose() const
+    {
+        return m_controller.GetDefaultSpawnPose();
+    }
+
+    AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerEditorComponent::GetAllSpawnPointInfos() const
+    {
+        return GetSpawnPoints();
+    }
+
+    bool ROS2SpawnerEditorComponent::ShouldActivateController() const
+    {
+        return false;
+    }
+
+    void ROS2SpawnerEditorComponent::Activate()
+    {
+        ROS2SpawnerEditorComponentBase::Activate();
+        ROS2SpawnerComponentConfig config = m_controller.GetConfiguration();
+        config.m_editorEntityId = GetEntityId();
+        AZ_Assert(config.m_editorEntityId.IsValid(), "Spawner component got an invalid entity id");
+        m_controller.SetConfiguration(config);
+        SpawnerRequestsBus::Handler::BusConnect(config.m_editorEntityId);
+    }
+
+    void ROS2SpawnerEditorComponent::Deactivate()
+    {
+        SpawnerRequestsBus::Handler::BusDisconnect();
+        ROS2SpawnerEditorComponentBase::Deactivate();
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "Spawner/ROS2SpawnerComponent.h"
+#include "Spawner/ROS2SpawnerComponentController.h"
+#include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <ROS2/Spawner/SpawnerBus.h>
+
+namespace ROS2
+{
+    using ROS2SpawnerEditorComponentBase = AzToolsFramework::Components::
+        EditorComponentAdapter<ROS2SpawnerComponentController, ROS2SpawnerComponent, ROS2SpawnerComponentConfig>;
+
+    class ROS2SpawnerEditorComponent
+        : public ROS2SpawnerEditorComponentBase
+        , public SpawnerRequestsBus::Handler
+    {
+    public:
+        AZ_EDITOR_COMPONENT(
+            ROS2SpawnerEditorComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AzToolsFramework::Components::EditorComponentBase);
+        ROS2SpawnerEditorComponent() = default;
+        explicit ROS2SpawnerEditorComponent(const ROS2SpawnerComponentConfig& configuration);
+        ~ROS2SpawnerEditorComponent() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //////////////////////////////////////////////////////////////////////////
+        // ROS2SpawnerEditorComponentBase interface overrides.
+        void Activate() override;
+        void Deactivate() override;
+        bool ShouldActivateController() const override;
+        //////////////////////////////////////////////////////////////////////////
+
+        //////////////////////////////////////////////////////////////////////////
+        // SpawnerRequestsBus::Handler overrides.
+        const AZ::Transform& GetDefaultSpawnPose() const override;
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetAllSpawnPointInfos() const override;
+        //////////////////////////////////////////////////////////////////////////
+
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetSpawnPoints() const;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -54,4 +54,8 @@ set(FILES
     Source/ROS2EditorSystemComponent.cpp
     Source/ROS2EditorSystemComponent.h
     Source/ROS2GemUtilities.cpp
+    Source/Spawner/ROS2SpawnerEditorComponent.cpp
+    Source/Spawner/ROS2SpawnerEditorComponent.h
+    Source/Spawner/ROS2SpawnPointEditorComponent.cpp
+    Source/Spawner/ROS2SpawnPointEditorComponent.h
 )

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -87,6 +87,10 @@ set(FILES
         Source/Spawner/ROS2SpawnerComponent.h
         Source/Spawner/ROS2SpawnPointComponent.cpp
         Source/Spawner/ROS2SpawnPointComponent.h
+        Source/Spawner/ROS2SpawnerComponentController.cpp
+        Source/Spawner/ROS2SpawnerComponentController.h
+        Source/Spawner/ROS2SpawnPointComponentController.cpp
+        Source/Spawner/ROS2SpawnPointComponentController.h
         Source/Utilities/Controllers/PidConfiguration.cpp
         Source/Utilities/PhysicsCallbackHandler.cpp
         Source/Utilities/ROS2Conversions.cpp

--- a/Templates/Ros2FleetRobotTemplate/Template/Levels/Warehouse/Warehouse.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Levels/Warehouse/Warehouse.prefab
@@ -88,17 +88,19 @@
                     "Id": 4373493893052679413
                 },
                 "Component_[4933737581982406853]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4933737581982406853,
-                    "m_template": {
-                        "$type": "ROS2SpawnerComponent",
-                        "Spawnables": {
-                            "proteus": {
-                                "assetId": {
-                                    "guid": "{80419AAD-14CF-528D-A477-8B202D4C9B6D}",
-                                    "subId": 1966583575
-                                },
-                                "assetHint": "proteus.spawnable"
+                    "$type": "ROS2SpawnerEditorComponent",
+                    "Id": 11259578117255245776,
+                    "Controller": {
+                        "Configuration": {
+                            "Editor entity id": "",
+                            "Spawnables": {
+                                "proteus": {
+                                    "assetId": {
+                                        "guid": "{80419AAD-14CF-528D-A477-8B202D4C9B6D}",
+                                        "subId": 1966583575
+                                    },
+                                    "assetHint": "proteus.spawnable"
+                                }
                             }
                         }
                     }
@@ -156,12 +158,13 @@
                     }
                 },
                 "Component_[2115342656585992410]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2115342656585992410,
-                    "m_template": {
-                        "$type": "ROS2SpawnPointComponent",
-                        "Name": "spawnPoint2",
-                        "Info": "spawnPoint2"
+                    "$type": "ROS2SpawnPointEditorComponent",
+                    "Id": 11018288690574626473,
+                    "Controller": {
+                        "Configuration": {
+                            "Name": "spawnPoint2",
+                            "Info": "spawnPoint2"
+                        }
                     }
                 },
                 "Component_[4848442694260332496]": {
@@ -220,12 +223,13 @@
                     }
                 },
                 "Component_[2115342656585992410]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2115342656585992410,
-                    "m_template": {
-                        "$type": "ROS2SpawnPointComponent",
-                        "Name": "spawnPoint3",
-                        "Info": "spawnPoint3"
+                    "$type": "ROS2SpawnPointEditorComponent",
+                    "Id": 11018288690574626473,
+                    "Controller": {
+                        "Configuration": {
+                            "Name": "spawnPoint3",
+                            "Info": "spawnPoint3"
+                        }
                     }
                 },
                 "Component_[4848442694260332496]": {
@@ -284,12 +288,13 @@
                     }
                 },
                 "Component_[2115342656585992410]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2115342656585992410,
-                    "m_template": {
-                        "$type": "ROS2SpawnPointComponent",
-                        "Name": "spawnPoint1",
-                        "Info": "spawnPoint1"
+                    "$type": "ROS2SpawnPointEditorComponent",
+                    "Id": 11018288690574626473,
+                    "Controller": {
+                        "Configuration": {
+                            "Name": "spawnPoint1",
+                            "Info": "spawnPoint1"
+                        }
                     }
                 },
                 "Component_[4848442694260332496]": {
@@ -348,12 +353,13 @@
                     }
                 },
                 "Component_[2115342656585992410]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2115342656585992410,
-                    "m_template": {
-                        "$type": "ROS2SpawnPointComponent",
-                        "Name": "spawnPoint4",
-                        "Info": "spawnPoint4"
+                    "$type": "ROS2SpawnPointEditorComponent",
+                    "Id": 11018288690574626473,
+                    "Controller": {
+                        "Configuration": {
+                            "Name": "spawnPoint4",
+                            "Info": "spawnPoint4"
+                        }
                     }
                 },
                 "Component_[4848442694260332496]": {


### PR DESCRIPTION
This is an enabler for further work on forward_branch. However, enhancements     are generic enough so it should be suitable for development after rebase
 
 ### Changes:
 
 * add namespace so multiple Spawners can be defined without collisions in service names. An empty namespace is an old behavior - a global namespace.
 * treat the typo in the spawn point name as an error.  Previously when there was no match initial_pose field was used. Now in order to use initial_pose the xml field has to be empty.
 * make code more idiomatic: use ROS2Conversion utils, structured bindings, avoid double-lookups for maps, etc.
 * replaced GetWorldProperties with GetModelList - the former is deprecated
 * utilize robot_namespace request field to apply custom name for spawned entities - custom name is applied to either the highest entity with ROS2 Frame Component, the highest entity with simulated body (either static or dynamic) or root itself in that order
