### PR TITLE
Add missing reflection to game version of Camera Component

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -28,6 +28,8 @@ namespace ROS2
 
     void ROS2CameraSensorComponent::Reflect(AZ::ReflectContext* context)
     {
+        CameraSensorConfiguration::Reflect(context);
+
         auto* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -30,8 +30,6 @@ namespace ROS2
 
     void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)
     {
-        CameraSensorConfiguration::Reflect(context);
-
         if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2CameraSensorEditorComponent, AzToolsFramework::Components::EditorComponentBase>()


### PR DESCRIPTION
This PR is addressing missing Reflection for one of the components. 

Project crashes due to the missing Configuration reflection in Camera Component when started from a Launcher

Everything works fine when the simulation is started from the Editor