### PR TITLE
Add ROS2 service to set gnss fix state

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -72,7 +72,7 @@ ly_add_target(
                     Gem::ImGui.imguilib
 )
 
-target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs)
+target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs std_srvs)
 target_depends_on_ros2_package(${gem_name}.Static control_toolbox 2.2.0 REQUIRED)
 
 ly_add_target(

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -16,6 +16,8 @@
 #include <ROS2/GNSS/GNSSPostProcessingRequestBus.h>
 #include <ROS2/Georeference/GeoreferenceBus.h>
 
+#include <string>
+
 namespace ROS2
 {
     namespace
@@ -63,6 +65,17 @@ namespace ROS2
 
         const auto publisherConfig = m_sensorConfiguration.m_publishersConfigurations[GNSSMsgType];
         const auto fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic);
+
+        const std::string service_name = std::string(fullTopic.data()) + "/set_fix";
+
+        m_setFixService = ros2Node->create_service<std_srvs::srv::SetBool>(
+            service_name,
+            [this](const std_srvs::srv::SetBool::Request::SharedPtr request, std_srvs::srv::SetBool::Response::SharedPtr response)
+            {
+                SetFixState(request->data);
+                response->success = true;
+            });
+
         m_gnssPublisher = ros2Node->create_publisher<sensor_msgs::msg::NavSatFix>(fullTopic.data(), publisherConfig.GetQoS());
 
         m_gnssMsg.header.frame_id = "gnss_frame_id";

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -16,8 +16,6 @@
 #include <ROS2/GNSS/GNSSPostProcessingRequestBus.h>
 #include <ROS2/Georeference/GeoreferenceBus.h>
 
-#include <string>
-
 namespace ROS2
 {
     namespace
@@ -66,7 +64,7 @@ namespace ROS2
         const auto publisherConfig = m_sensorConfiguration.m_publishersConfigurations[GNSSMsgType];
         const auto fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic);
 
-        const std::string service_name = std::string(fullTopic.data()) + "/set_fix";
+        const AZStd::string service_name = AZStd::string(fullTopic.data()) + "/set_fix";
 
         m_setFixService = ros2Node->create_service<std_srvs::srv::SetBool>(
             service_name,

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.h
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.h
@@ -13,6 +13,8 @@
 #include <ROS2/Sensor/ROS2SensorComponentBase.h>
 #include <rclcpp/publisher.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace ROS2
 {
@@ -51,6 +53,8 @@ namespace ROS2
         [[nodiscard]] AZ::Transform GetCurrentPose() const;
 
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::NavSatFix>> m_gnssPublisher;
+        rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr m_setFixService;
+
         sensor_msgs::msg::NavSatFix m_gnssMsg;
         bool m_isFix = true;
     };


### PR DESCRIPTION
Added option to set GNSS fix state `ros2 service call /ns/set_fix  std_srvs/srv/SetBool "{data: false}" ` individual for each gnss