### PR TITLE
Remove empty target from Warehouse Automation Gem.

### DIFF
--- a/Gems/WarehouseAutomation/Code/CMakeLists.txt
+++ b/Gems/WarehouseAutomation/Code/CMakeLists.txt
@@ -110,27 +110,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
     )
 
-    # The ${gem_name}.Editor.Private.Object target is an internal target
-    # which is only to be used by this gems CMakeLists.txt and any subdirectories
-    # Other gems should not use this target
-    ly_add_target(
-        NAME ${gem_name}.Editor.Private.Object STATIC
-        NAMESPACE Gem
-        FILES_CMAKE
-            warehouseautomation_editor_private_files.cmake
-        TARGET_PROPERTIES
-            O3DE_PRIVATE_TARGET TRUE
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Include
-                Source
-        BUILD_DEPENDENCIES
-            PUBLIC
-                AZ::AzToolsFramework
-                Gem::PhysX.Editor.Static
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
-    )
-
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
@@ -146,7 +125,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 Gem::${gem_name}.Editor.API
             PRIVATE
-                Gem::${gem_name}.Editor.Private.Object
+                AZ::AzToolsFramework
+                ${gem_name}.Private.Object
     )
 
     # By default, we will specify that the above target ${gem_name} would be used by

--- a/Gems/WarehouseAutomation/Code/warehouseautomation_editor_private_files.cmake
+++ b/Gems/WarehouseAutomation/Code/warehouseautomation_editor_private_files.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-set(FILES
-)


### PR DESCRIPTION
This is partial cherry-pick from https://github.com/o3de/o3de-extras/pull/665.
It caused a compilation error on the engine-centric build. It is manually cherry-picked from PR #665.

## What does this PR do?

It removes empty targets from  Warehouse Automation Gem.

## How was this PR tested?

Build against point release o3de d17eb34646792531c840f200d05ea2b3c6e3320b and target branch of o3de-extras
