### PR TITLE
[ROS2] Refactor and simplify Lidar raycaster range configuration 

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -101,6 +101,14 @@ namespace ROS2
         AZStd::vector<float> m_intensities;
     };
 
+    //! Structure used to describe both minimal and maximal
+    //! ray travel distance in meters.
+    struct Range
+    {
+        float m_min{ 0.0f };
+        float m_max{ 0.0f };
+    };
+
     //! Interface class that allows for communication with a single Lidar instance.
     class LidarRaycasterRequests
     {
@@ -112,16 +120,9 @@ namespace ROS2
         //! vector in the positive z direction first by the y, next by the z axis. The x axis is currently not included in calculations.
         virtual void ConfigureRayOrientations(const AZStd::vector<AZ::Vector3>& orientations) = 0;
 
-        //! Configures ray maximum travel distance.
-        //! @param range Ray range in meters.
-        virtual void ConfigureRayRange(float range) = 0;
-
-        //! Configures ray minimum travel distance.
-        //! @param range Ray range in meters.
-        virtual void ConfigureMinimumRayRange(float range)
-        {
-            AZ_Assert(false, "This Lidar Implementation does not support minimum ray range configurations!");
-        }
+        //! Configures ray range.
+        //! @param range Ray range.
+        virtual void ConfigureRayRange(Range range) = 0;
 
         //! Configures result flags.
         //! @param flags Raycast result flags define set of data types returned by lidar.
@@ -211,11 +212,6 @@ namespace ROS2
 
     protected:
         ~LidarRaycasterRequests() = default;
-
-        static void ValidateRayRange([[maybe_unused]] float range)
-        {
-            AZ_Assert(range > 0.0f, "Provided ray range was of incorrect value: Ray range value must be greater than zero.")
-        }
 
         static void ValidateRayOrientations([[maybe_unused]] const AZStd::vector<AZ::Vector3>& orientations)
         {

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -58,10 +58,8 @@ namespace ROS2
         LidarRaycasterRequestBus::Event(m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureRayOrientations, m_lastRotations);
         LidarRaycasterRequestBus::Event(
             m_lidarRaycasterId,
-            &LidarRaycasterRequestBus::Events::ConfigureMinimumRayRange,
-            m_lidarConfiguration.m_lidarParameters.m_minRange);
-        LidarRaycasterRequestBus::Event(
-            m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureRayRange, m_lidarConfiguration.m_lidarParameters.m_maxRange);
+            &LidarRaycasterRequestBus::Events::ConfigureRayRange,
+            Range{ m_lidarConfiguration.m_lidarParameters.m_minRange, m_lidarConfiguration.m_lidarParameters.m_maxRange });
 
         if ((m_lidarConfiguration.m_lidarSystemFeatures & LidarSystemFeatures::Noise) &&
             m_lidarConfiguration.m_lidarParameters.m_isNoiseEnabled)

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -44,7 +44,6 @@ namespace ROS2
         , m_sceneEntityId{ lidarRaycaster.m_sceneEntityId }
         , m_sceneHandle{ lidarRaycaster.m_sceneHandle }
         , m_resultFlags{ lidarRaycaster.m_resultFlags }
-        , m_minRange{ lidarRaycaster.m_minRange }
         , m_range{ lidarRaycaster.m_range }
         , m_addMaxRangePoints{ lidarRaycaster.m_addMaxRangePoints }
         , m_rayRotations{ AZStd::move(lidarRaycaster.m_rayRotations) }
@@ -72,15 +71,9 @@ namespace ROS2
         }
     }
 
-    void LidarRaycaster::ConfigureRayRange(float range)
+    void LidarRaycaster::ConfigureRayRange(Range range)
     {
-        ValidateRayRange(range);
         m_range = range;
-    }
-
-    void LidarRaycaster::ConfigureMinimumRayRange(float range)
-    {
-        m_minRange = range;
     }
 
     void LidarRaycaster::ConfigureRaycastResultFlags(RaycastResultFlags flags)
@@ -101,7 +94,7 @@ namespace ROS2
             AZStd::shared_ptr<AzPhysics::RayCastRequest> request = AZStd::make_shared<AzPhysics::RayCastRequest>();
             request->m_start = lidarPosition;
             request->m_direction = direction;
-            request->m_distance = m_range;
+            request->m_distance = m_range->m_max;
             request->m_reportMultipleHits = false;
 
             request->m_filterCallback = [ignoredCollisionLayers = this->m_ignoredCollisionLayers](
@@ -122,7 +115,7 @@ namespace ROS2
     RaycastResult LidarRaycaster::PerformRaycast(const AZ::Transform& lidarTransform)
     {
         AZ_Assert(!m_rayRotations.empty(), "Ray poses are not configured. Unable to Perform a raycast.");
-        AZ_Assert(m_range > 0.0f, "Ray range is not configured. Unable to Perform a raycast.");
+        AZ_Assert(m_range.has_value(), "Ray range is not configured. Unable to Perform a raycast.");
 
         if (m_sceneHandle == AzPhysics::InvalidSceneHandle)
         {
@@ -149,13 +142,13 @@ namespace ROS2
         AZ_Assert(requestResults.size() == rayDirections.size(), "Request size should be equal to directions size");
         const auto localTransform =
             AZ::Transform::CreateFromQuaternionAndTranslation(lidarTransform.GetRotation(), lidarTransform.GetTranslation()).GetInverse();
-        const float maxRange = m_addMaxRangePoints ? m_range : AZStd::numeric_limits<float>::infinity();
+        const float maxRange = m_addMaxRangePoints ? m_range->m_max : AZStd::numeric_limits<float>::infinity();
 
         for (int i = 0; i < requestResults.size(); i++)
         {
             const auto& requestResult = requestResults[i];
             float hitRange = requestResult ? requestResult.m_hits[0].m_distance : maxRange;
-            if (hitRange < m_minRange)
+            if (hitRange < m_range->m_min)
             {
                 hitRange = -AZStd::numeric_limits<float>::infinity();
             }

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -27,8 +27,7 @@ namespace ROS2
     protected:
         // LidarRaycasterRequestBus overrides
         void ConfigureRayOrientations(const AZStd::vector<AZ::Vector3>& orientations) override;
-        void ConfigureRayRange(float range) override;
-        void ConfigureMinimumRayRange(float range) override;
+        void ConfigureRayRange(Range range) override;
         void ConfigureRaycastResultFlags(RaycastResultFlags flags) override;
 
         RaycastResult PerformRaycast(const AZ::Transform& lidarTransform) override;
@@ -45,8 +44,7 @@ namespace ROS2
         AzPhysics::SceneHandle m_sceneHandle{ AzPhysics::InvalidSceneHandle };
 
         RaycastResultFlags m_resultFlags{ RaycastResultFlags::Points };
-        float m_minRange{ 0.0f };
-        float m_range{ 1.0f };
+        AZStd::optional<Range> m_range{};
         bool m_addMaxRangePoints{ false };
         AZStd::vector<AZ::Quaternion> m_rayRotations{ { AZ::Quaternion::CreateZero() } };
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
@@ -81,5 +81,10 @@ namespace ROS2
     private:
         bool IsLayersVisible() const;
         [[nodiscard]] bool IsNoiseConfigVisible() const;
+
+        static AZ::Outcome<void, AZStd::string> ValidateRange(float minRange, float maxRange);
+
+        AZ::Outcome<void, AZStd::string> ValidateMinRange(void* newValue, const AZ::TypeId& valueType) const;
+        AZ::Outcome<void, AZStd::string> ValidateMaxRange(void* newValue, const AZ::TypeId& valueType) const;
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This PR simplifies `LidarRaycaster` range configuration (in preparation for #736). It also adds proper, editor-side range value validation.

This PR was developed alongside _TODO_.

_**Note:**_ _Although this PR is ready for review, it should not be merged into the `feature/lidar_intensity` branch and rather into the `development` branch once intensity pull request is merged._

## How was this PR tested?

This pull request was tested in a simple test project under various lidar configurations.