### PR TITLE
Update rgl/stable-dev gem version

### DIFF
--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "2.0.0",
+    "version": "3.2.0",
     "platforms": [
         "Linux"
     ],


### PR DESCRIPTION
As the rgl/stable-dev branch is intended to work with the newest RGL gem development branch, the gems version must be updated to satisfy RGL gem's version requirements
