### PR TITLE
Lidar: Fixes for reflectivity and point cloud message

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -12,6 +12,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/optional.h>
 #include <ROS2/Communication/QoS.h>
 #include <ROS2/Lidar/RaycastResults.h>
 
@@ -118,10 +119,9 @@ namespace ROS2
 
         //! Schedules a raycast that originates from the point described by the lidarTransform.
         //! @param lidarTransform Current transform from global to lidar reference frame.
-        //! @param flags Used to request different kinds of data returned by raycast query
-        //! @return Results of the raycast in the requested form if the raycast was successfull or an error message if it was not.
+        //! @return Results of the raycast in the requested form if the raycast was successful or an error message if it was not.
         //! The returned error messages are c-style string literals which are statically allocated and therefore do not need to be
-        //! dealocated.
+        //! deallocated.
         virtual AZ::Outcome<RaycastResults, const char*> PerformRaycast(const AZ::Transform& lidarTransform) = 0;
 
         //! Configures ray Gaussian Noise parameters.
@@ -160,10 +160,18 @@ namespace ROS2
         //! @param returnNonHits Should the non hit rays be included in returned results?
         virtual void ConfigureNonHitReturn([[maybe_unused]] bool returnNonHits) = 0;
 
+        //! Configures non-hit values for distances closer than a minimum range and beyond a maximum range.
+        //! By default, non-hit values are set to infinity.
+        //! @param range non hit values at range. Use empty optional to reset to default.
+        virtual void ConfigureNonHitValues([[maybe_unused]] AZStd::optional<ROS2::RayRange> range)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support configurable non hit values!");
+        }
+
         //! Configures ring IDs of the requested rays.
         //! ID count must be equal to that of the ray count (@see ConfigureRayOrientations).
         //! @param ringIds List of IDs for each of the requested rays.
-        virtual void ConfigureRayRingIds(const AZStd::vector<AZ::s32>& ringIds)
+        virtual void ConfigureRayRingIds([[maybe_unused]] const AZStd::vector<AZ::s32>& ringIds)
         {
             AZ_Assert(false, "This Lidar Implementation does not support ring ids!")
         }

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -24,7 +24,8 @@ namespace ROS2
         Intensity =             1 << 3,
         Segmentation =          1 << 4,
         RingIds =               1 << 5,
-        All =                   (1 << 6) - 1, // All feature bits enabled.
+        Reflectivity =          1 << 6,
+        All =                   (1 << 7) - 1, // All feature bits enabled.
         // clang-format on
     };
 

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
@@ -24,7 +24,8 @@ namespace ROS2
         SegmentationData        = (1 << 3), //!< return segmentation data
         IsHit                   = (1 << 4), //!< return ray hit booleans
         Ring                    = (1 << 5), //!< return ray ring ids
-        All                     = (1 << 6) - 1U,
+        Reflectivity            = (1 << 6),
+        All                     = (1 << 7) - 1U,
         // clang-format on
     };
 
@@ -79,6 +80,12 @@ namespace ROS2
     struct ResultTraits<RaycastResultFlags::Ring>
     {
         using Type = AZ::u16;
+    };
+
+    template<>
+    struct ResultTraits<RaycastResultFlags::Reflectivity>
+    {
+        using Type = float;
     };
 
     //! Class used for storing the results of a raycast.
@@ -143,6 +150,7 @@ namespace ROS2
         FieldInternal<RaycastResultFlags::SegmentationData> m_segmentationData;
         FieldInternal<RaycastResultFlags::IsHit> m_isHit;
         FieldInternal<RaycastResultFlags::Ring> m_ringId;
+        FieldInternal<RaycastResultFlags::Reflectivity> m_reflectivities;
         size_t m_count{};
         RaycastResultFlags m_flags;
     };
@@ -213,6 +221,12 @@ namespace ROS2
     inline const RaycastResults::FieldInternal<RaycastResultFlags::Ring>& RaycastResults::GetField<RaycastResultFlags::Ring>() const
     {
         return m_ringId;
+    }
+
+    template<>
+    inline const RaycastResults::FieldInternal<RaycastResultFlags::Reflectivity>& RaycastResults::GetField<RaycastResultFlags::Reflectivity>() const
+    {
+        return m_reflectivities;
     }
 
     template<RaycastResultFlags F>

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/base.h>
 #include <AzCore/std/containers/span.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/typetraits/type_identity.h>
@@ -224,7 +225,8 @@ namespace ROS2
     }
 
     template<>
-    inline const RaycastResults::FieldInternal<RaycastResultFlags::Reflectivity>& RaycastResults::GetField<RaycastResultFlags::Reflectivity>() const
+    inline const RaycastResults::FieldInternal<RaycastResultFlags::Reflectivity>& RaycastResults::GetField<
+        RaycastResultFlags::Reflectivity>() const
     {
         return m_reflectivities;
     }

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -46,6 +46,11 @@ namespace ROS2
             flags |= RaycastResultFlags::Intensity;
         }
 
+        if (configuration.m_lidarSystemFeatures & LidarSystemFeatures::Reflectivity)
+        {
+            flags |= RaycastResultFlags::Reflectivity;
+        }
+
         if (configuration.m_lidarSystemFeatures & LidarSystemFeatures::Segmentation && configuration.m_isSegmentationEnabled)
         {
             if (ClassSegmentationInterface::Get())

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -134,20 +134,27 @@ namespace ROS2
         }
 
         {
-            const bool returnNonHits =
-                IsFlagEnabled(RaycastResultFlags::IsHit, GetResultFlags()) || m_lidarConfiguration.m_addPointsAtMax || m_is2DLidar;
+            const bool returnNonHits = IsFlagEnabled(RaycastResultFlags::IsHit, GetResultFlags()) ||
+                m_lidarConfiguration.m_addPointsAtMin || m_lidarConfiguration.m_addPointsAtMax || m_is2DLidar;
             LidarRaycasterRequestBus::Event(m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureNonHitReturn, returnNonHits);
         }
+
+        const auto nonHitRange = (m_lidarConfiguration.m_addPointsAtMin)
+            ? AZStd::make_optional(RayRange{ 0.0f, 0.0f })
+            : AZStd::make_optional(
+                  RayRange{ m_lidarConfiguration.m_lidarParameters.m_minRange, m_lidarConfiguration.m_lidarParameters.m_maxRange });
+
+        LidarRaycasterRequestBus::Event(m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureNonHitValues, nonHitRange);
     }
 
     void LidarCore::UpdatePoints(const RaycastResults& results)
     {
         const auto pointsField = results.GetConstFieldSpan<RaycastResultFlags::Point>().value();
-        if (!m_lidarConfiguration.m_addPointsAtMax && results.IsFieldPresent<RaycastResultFlags::IsHit>())
+        if (!m_lidarConfiguration.m_addPointsAtMin && !m_lidarConfiguration.m_addPointsAtMax &&
+            results.IsFieldPresent<RaycastResultFlags::IsHit>())
         {
             m_lastPoints.clear();
             m_lastPoints.reserve(pointsField.size());
-
 
             const auto isHit = results.GetConstFieldSpan<RaycastResultFlags::IsHit>();
             auto isHitIt = isHit->begin();

--- a/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.cpp
@@ -24,6 +24,7 @@ namespace ROS2
                 ->Field("IgnoredLayerIndices", &LidarSensorConfiguration::m_ignoredCollisionLayers)
                 ->Field("ExcludedEntities", &LidarSensorConfiguration::m_excludedEntities)
                 ->Field("IsSegmentationEnabled", &LidarSensorConfiguration::m_isSegmentationEnabled)
+                ->Field("PointsAtMin", &LidarSensorConfiguration::m_addPointsAtMin)
                 ->Field("PointsAtMax", &LidarSensorConfiguration::m_addPointsAtMax);
 
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
@@ -68,9 +69,16 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Visibility, &LidarSensorConfiguration::IsSegmentationConfigurationVisible)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
+                        &LidarSensorConfiguration::m_addPointsAtMin,
+                        "Points at Min",
+                        "If set true LiDAR will produce points at min range for free space (only min or max is allowed)")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &LidarSensorConfiguration::OnAddPointsMinSelected)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &LidarSensorConfiguration::m_addPointsAtMax,
                         "Points at Max",
-                        "If set true LiDAR will produce points at max range for free space");
+                        "If set true LiDAR will produce points at max range for free space  (only min or max is allowed)")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &LidarSensorConfiguration::OnAddPointsMaxSelected);
             }
         }
     }
@@ -158,6 +166,24 @@ namespace ROS2
     {
         FetchLidarImplementationFeatures();
         UpdateShowNoise();
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZ::Crc32 LidarSensorConfiguration::OnAddPointsMinSelected()
+    {
+        if (m_addPointsAtMin)
+        {
+            m_addPointsAtMax = false;
+        }
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZ::Crc32 LidarSensorConfiguration::OnAddPointsMaxSelected()
+    {
+        if (m_addPointsAtMax)
+        {
+            m_addPointsAtMin = false;
+        }
         return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.h
@@ -40,8 +40,8 @@ namespace ROS2
         AZStd::vector<AZ::EntityId> m_excludedEntities;
 
         bool m_isSegmentationEnabled = false;
+        bool m_addPointsAtMin = false;
         bool m_addPointsAtMax = false;
-        bool m_returnNonHits = false;
 
     private:
         bool IsConfigurationVisible() const;
@@ -53,6 +53,8 @@ namespace ROS2
 
         AZ::Crc32 OnLidarModelSelected();
         AZ::Crc32 OnLidarImplementationSelected();
+        AZ::Crc32 OnAddPointsMinSelected();
+        AZ::Crc32 OnAddPointsMaxSelected();
 
         //! Get all models this configuration can be set to (for example all 2D lidar models).
         AZStd::vector<AZStd::string> GetAvailableModels() const;

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -251,16 +251,16 @@ namespace ROS2
         const float horizontalStep = (maxHorAngle - minHorAngle) / static_cast<float>(lidarTemplate.m_numberOfIncrements);
 
         AZStd::vector<AZ::Vector3> rotations;
-        for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
+        for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
         {
-            const float yaw = minHorAngle + incr * horizontalStep;
-            for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
+            const float pitch = minVertAngle + layer * verticalStep;
+            for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
             {
-                const float pitch = minVertAngle + layer * verticalStep;
-
+                const float yaw = minHorAngle + incr * horizontalStep;
                 rotations.emplace_back(0.0f, pitch, yaw);
             }
         }
+
 
         return rotations;
     }
@@ -269,9 +269,9 @@ namespace ROS2
     {
         AZStd::vector<AZ::s32> ringIds;
         ringIds.reserve(lidarTemplate.m_numberOfIncrements * lidarTemplate.m_layers);
-        for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
+        for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
         {
-            for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
+            for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
             {
                 ringIds.push_back(layer);
             }

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.cpp
@@ -255,4 +255,17 @@ namespace ROS2
 
         return providerFlags;
     }
+
+    AZStd::optional<float> GetUnitMultiplierValue(DistanceUnits units)
+    {
+        switch (units)
+        {
+            // clang-format off
+        case DistanceUnits::Meters: return 1.0f;
+        case DistanceUnits::Centimeters: return 1.0e2f;
+        case DistanceUnits::Millimeters: return 1.0e3f;
+        case DistanceUnits::Custom: return AZStd::nullopt;
+            // clang-format on
+        }
+    }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.cpp
@@ -62,7 +62,8 @@ namespace ROS2
         case FieldFlags::RangeU32:                  return RaycastResultFlags::Range;
         case FieldFlags::SegmentationData96:        return RaycastResultFlags::SegmentationData;
         case FieldFlags::RingU8:
-        case FieldFlags::RingU16:                    return RaycastResultFlags::Ring;
+        case FieldFlags::RingU16:                   return RaycastResultFlags::Ring;
+        case FieldFlags::ReflectivityU16:           return RaycastResultFlags::Reflectivity;
         default:                                    return RaycastResultFlags::None;
             // clang-format on
         }

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.h
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageFormat.h
@@ -173,4 +173,14 @@ namespace ROS2
 
     using Pc2MessageFormat = AZStd::vector<FieldFormat>;
     RaycastResultFlags GetNecessaryProviders(const Pc2MessageFormat& messageFormat);
+
+    enum class DistanceUnits
+    {
+        Meters,
+        Centimeters,
+        Millimeters,
+        Custom,
+    };
+
+    AZStd::optional<float> GetUnitMultiplierValue(DistanceUnits units);
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.cpp
@@ -49,6 +49,10 @@ namespace ROS2
                 break;
             case RaycastResultFlags::Ring:
                 wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Ring>(results, fielFlag, i, skipNonHits);
+                break;
+            case RaycastResultFlags::Reflectivity:
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Reflectivity>(results, fielFlag, i, skipNonHits);
+                break;
             default:
                 break;
             }

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.cpp
@@ -26,8 +26,8 @@ namespace ROS2
     {
         for (size_t i = 0; i < m_message.m_fieldFlags.size(); ++i)
         {
-            const auto fielFlag = m_message.m_fieldFlags[i];
-            if (IsPadding(fielFlag))
+            const auto fieldFlag = m_message.m_fieldFlags[i];
+            if (IsPadding(fieldFlag))
             {
                 continue;
             }
@@ -36,22 +36,22 @@ namespace ROS2
             switch (GetFieldProvider(m_message.m_fieldFlags.at(i)))
             {
             case RaycastResultFlags::Point:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Point>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Point>(results, fieldFlag, i, skipNonHits);
                 break;
             case RaycastResultFlags::Range:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Range>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Range>(results, fieldFlag, i, skipNonHits);
                 break;
             case RaycastResultFlags::Intensity:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Intensity>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Intensity>(results, fieldFlag, i, skipNonHits);
                 break;
             case RaycastResultFlags::SegmentationData:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::SegmentationData>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::SegmentationData>(results, fieldFlag, i, skipNonHits);
                 break;
             case RaycastResultFlags::Ring:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Ring>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Ring>(results, fieldFlag, i, skipNonHits);
                 break;
             case RaycastResultFlags::Reflectivity:
-                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Reflectivity>(results, fielFlag, i, skipNonHits);
+                wasWrittenTo = WriteResultIfPresent<RaycastResultFlags::Reflectivity>(results, fieldFlag, i, skipNonHits);
                 break;
             default:
                 break;

--- a/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.h
+++ b/Gems/ROS2/Code/Source/Lidar/Publishing/PointCloudMessageWriter.h
@@ -210,6 +210,24 @@ namespace ROS2
         return AZ::Success();
     }
 
+    template<>
+    inline AZ::Outcome<void, AZStd::string_view> PointCloudMessageWriter::
+        AssignResultFieldValue<RaycastResultFlags::Reflectivity, FieldFlags::ReflectivityU16>(
+            const ResultTraits<RaycastResultFlags::Reflectivity>::Type& resultValue,
+            FieldTraits<FieldFlags::ReflectivityU16>::Type& messageFieldValue)
+    {
+        if (resultValue > aznumeric_cast<float>(AZStd::numeric_limits<AZ::u16>::max()))
+        {
+            messageFieldValue = AZStd::numeric_limits<AZ::u16>::max();
+        }
+        else
+        {
+            messageFieldValue = aznumeric_cast<AZ::u16>(resultValue);
+        }
+
+        return AZ::Success();
+    }
+
     template<RaycastResultFlags R>
     bool PointCloudMessageWriter::WriteResultIfPresent(const RaycastResults& results, FieldFlags fieldFlag, size_t index, bool skipNonHits)
     {
@@ -319,6 +337,20 @@ namespace ROS2
         {
             WriteResultToMessageField<RaycastResultFlags::Ring, FieldFlags::RingU16>(
                 results.GetConstFieldSpan<RaycastResultFlags::Ring>().value(), fieldIndex, isHit);
+        }
+    }
+
+    template<>
+    inline void PointCloudMessageWriter::WriteResult<RaycastResultFlags::Reflectivity>(
+        const RaycastResults& results,
+        FieldFlags fieldFlag,
+        size_t fieldIndex,
+        AZStd::optional<RaycastResults::ConstFieldSpan<RaycastResultFlags::IsHit>> isHit)
+    {
+        if (fieldFlag == FieldFlags::ReflectivityU16)
+        {
+            WriteResultToMessageField<RaycastResultFlags::Reflectivity, FieldFlags::ReflectivityU16>(
+                results.GetConstFieldSpan<RaycastResultFlags::Reflectivity>().value(), fieldIndex, isHit);
         }
     }
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -33,8 +33,7 @@ namespace ROS2
                 ->Version(3)
                 ->Field("lidarCore", &ROS2LidarSensorComponent::m_lidarCore)
                 ->Field("messageFormat", &ROS2LidarSensorComponent::m_messageFormat)
-                ->Field("pointCloudIsDense", &ROS2LidarSensorComponent::m_pointcloudIsDense)
-                ->Field("pointCloudOrdering", &ROS2LidarSensorComponent::m_pointcloudOrderingEnabled)
+                ->Field("pointcloudIsCompact", &ROS2LidarSensorComponent::m_pointcloudIsCompact)
                 ->Field("distanceUnits", &ROS2LidarSensorComponent::m_distanceUnits)
                 ->Field("distanceMultiplier", &ROS2LidarSensorComponent::m_distanceMultiplier);
 
@@ -62,18 +61,11 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ROS2LidarSensorComponent::OnMessageFormatChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ROS2LidarSensorComponent::m_pointcloudIsDense,
-                        "Dense pointcloud",
+                        &ROS2LidarSensorComponent::m_pointcloudIsCompact,
+                        "Compact pointcloud",
                         "If enabled, only the points that hit an obstacle are processed and published. Having this option enabled improves "
                         "performance but disallows pointcloud ordering and points at max.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ROS2LidarSensorComponent::OnDensePointcloudChanged)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &ROS2LidarSensorComponent::m_pointcloudOrderingEnabled,
-                        "Pointcloud ordering",
-                        "Message's width and height match those of the used ray pattern. Only available for sparse (non-dense) "
-                        "pointclouds.")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2LidarSensorComponent::IsPointcloudOrderingVisible)
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox,
                         &ROS2LidarSensorComponent::m_distanceUnits,
@@ -200,19 +192,14 @@ namespace ROS2
 
     RaycastResultFlags ROS2LidarSensorComponent::GetRequestResultFlags() const
     {
-        auto flags = GetNecessaryProviders(m_messageFormat) | RaycastResultFlags::Point; // We need points for visualisation.
+        auto flags = GetNecessaryProviders(m_messageFormat) | RaycastResultFlags::Point; // We need points for visualization.
 
-        if (!m_pointcloudIsDense)
+        if (!m_pointcloudIsCompact)
         {
             flags |= RaycastResultFlags::IsHit;
         }
 
         return flags;
-    }
-
-    bool ROS2LidarSensorComponent::IsPointcloudOrderingVisible() const
-    {
-        return !m_pointcloudIsDense;
     }
 
     bool ROS2LidarSensorComponent::IsDistanceUnitsVisible() const
@@ -270,21 +257,21 @@ namespace ROS2
 
         const size_t rayLayerCount = m_lidarCore.m_lidarConfiguration.m_lidarParameters.m_layers;
         const size_t rayCountPerLayer = m_lidarCore.m_lidarConfiguration.m_lidarParameters.m_numberOfIncrements;
-        if (m_pointcloudOrderingEnabled && results.GetCount() != rayLayerCount * rayCountPerLayer)
+        if (!m_pointcloudIsCompact && results.GetCount() != rayLayerCount * rayCountPerLayer)
         {
             return AZ::Failure("Received raycast results with dimensions that were not expected.");
         }
 
-        const size_t pcWidth = m_pointcloudOrderingEnabled ? rayCountPerLayer : results.GetCount();
-        const size_t pcHeight = m_pointcloudOrderingEnabled ? rayLayerCount : 1U;
+        const size_t pcWidth = m_pointcloudIsCompact ? results.GetCount() : rayCountPerLayer;
+        const size_t pcHeight = m_pointcloudIsCompact ? 1U : rayLayerCount;
         m_pointCloudMessageWriter->Reset(
             GetEntity()->FindComponent<ROS2FrameComponent>()->GetFrameID(),
             ROS2Interface::Get()->GetROSTimestamp(),
             pcWidth,
             pcHeight,
-            m_pointcloudIsDense);
+            !m_pointcloudIsCompact);
 
-        m_pointCloudMessageWriter->WriteResults(results, !m_pointcloudIsDense && !m_lidarCore.m_lidarConfiguration.m_addPointsAtMax);
+        m_pointCloudMessageWriter->WriteResults(results, m_pointcloudIsCompact);
 
         PC2PostProcessingRequestBus::Event(
             GetEntityId(), &PC2PostProcessingRequests::ApplyPostProcessing, m_pointCloudMessageWriter->GetMessage());
@@ -296,9 +283,9 @@ namespace ROS2
 
     AZ::Crc32 ROS2LidarSensorComponent::OnLidarCoreChanged()
     {
-        if (m_lidarCore.m_lidarConfiguration.m_addPointsAtMax)
+        if (m_lidarCore.m_lidarConfiguration.m_addPointsAtMin || m_lidarCore.m_lidarConfiguration.m_addPointsAtMax)
         {
-            m_pointcloudIsDense = false;
+            m_pointcloudIsCompact = false;
             return AZ::Edit::PropertyRefreshLevels::EntireTree;
         }
 
@@ -338,13 +325,13 @@ namespace ROS2
 
     AZ::Crc32 ROS2LidarSensorComponent::OnDensePointcloudChanged()
     {
-        if (m_pointcloudIsDense)
+        if (m_pointcloudIsCompact)
         {
+            m_lidarCore.m_lidarConfiguration.m_addPointsAtMin = false;
             m_lidarCore.m_lidarConfiguration.m_addPointsAtMax = false;
-            m_pointcloudOrderingEnabled = false;
         }
 
-        // This is to ensure that visibility of pointcloud ordering is updated.
+        // This is to ensure that visibility of lidar configuration is updated.
         return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -51,19 +51,24 @@ namespace ROS2
         void TransformToLidarLocalSpace(AZStd::span<AZ::Vector3> pointSpan) const;
         RaycastResultFlags GetRequestResultFlags() const;
         bool IsPointcloudOrderingVisible() const;
+        bool IsDistanceUnitsVisible() const;
+        bool IsDistanceMultiplierVisible() const;
         void FrequencyTick();
         AZ::Outcome<void, const char*> PublishRaycastResults(const RaycastResults& results);
         AZ::Crc32 OnLidarCoreChanged();
         AZ::Crc32 OnMessageFormatChanged();
         AZ::Crc32 OnDensePointcloudChanged();
         AZ::Crc32 GenerateMessageFormat();
-
+        AZ::Crc32 OnDistanceUnitsChanged();
+        void ApplyUnitConversion(RaycastResults& raycastResults);
 
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
         std::shared_ptr<rclcpp::Publisher<vision_msgs::msg::LabelInfo>> m_segmentationClassesPublisher;
 
         AZStd::optional<PointCloudMessageWriter> m_pointCloudMessageWriter;
         Pc2MessageFormat m_messageFormat;
+        DistanceUnits m_distanceUnits{ DistanceUnits::Meters };
+        float m_distanceMultiplier{ GetUnitMultiplierValue(DistanceUnits::Meters).value() };
 
         LidarCore m_lidarCore;
         LidarId m_lidarRaycasterId;

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -50,7 +50,6 @@ namespace ROS2
         static const Pc2MessageFormat& GetDefaultMessageFormat();
         void TransformToLidarLocalSpace(AZStd::span<AZ::Vector3> pointSpan) const;
         RaycastResultFlags GetRequestResultFlags() const;
-        bool IsPointcloudOrderingVisible() const;
         bool IsDistanceUnitsVisible() const;
         bool IsDistanceMultiplierVisible() const;
         void FrequencyTick();
@@ -73,7 +72,6 @@ namespace ROS2
         LidarCore m_lidarCore;
         LidarId m_lidarRaycasterId;
 
-        bool m_pointcloudIsDense{ true };
-        bool m_pointcloudOrderingEnabled{ false };
+        bool m_pointcloudIsCompact{ false };
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/RaycastResults.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/RaycastResults.cpp
@@ -19,6 +19,7 @@ namespace ROS2
         EnsureFlagSatisfied<RaycastResultFlags::SegmentationData>(flags, count);
         EnsureFlagSatisfied<RaycastResultFlags::IsHit>(flags, count);
         EnsureFlagSatisfied<RaycastResultFlags::Ring>(flags, count);
+        EnsureFlagSatisfied<RaycastResultFlags::Reflectivity>(flags, count);
     }
 
     RaycastResults::RaycastResults(RaycastResults&& other)
@@ -28,6 +29,7 @@ namespace ROS2
         , m_segmentationData{ AZStd::move(other.m_segmentationData) }
         , m_isHit{ AZStd::move(other.m_isHit) }
         , m_ringId{ AZStd::move(other.m_ringId) }
+        , m_reflectivities{ AZStd::move(other.m_reflectivities) }
         , m_count{ other.m_count }
         , m_flags{ other.m_flags }
     {
@@ -44,6 +46,7 @@ namespace ROS2
         ClearFieldIfPresent<RaycastResultFlags::SegmentationData>();
         ClearFieldIfPresent<RaycastResultFlags::IsHit>();
         ClearFieldIfPresent<RaycastResultFlags::Ring>();
+        ClearFieldIfPresent<RaycastResultFlags::Reflectivity>();
     }
 
     void RaycastResults::Resize(size_t count)
@@ -55,6 +58,7 @@ namespace ROS2
         ResizeFieldIfPresent<RaycastResultFlags::SegmentationData>(count);
         ResizeFieldIfPresent<RaycastResultFlags::IsHit>(count);
         ResizeFieldIfPresent<RaycastResultFlags::Ring>(count);
+        ResizeFieldIfPresent<RaycastResultFlags::Reflectivity>(count);
     }
 
     RaycastResults& RaycastResults::operator=(RaycastResults&& other)
@@ -76,6 +80,7 @@ namespace ROS2
         m_segmentationData = AZStd::move(other.m_segmentationData);
         m_isHit = AZStd::move(other.m_isHit);
         m_ringId = AZStd::move(other.m_ringId);
+        m_reflectivities = AZStd::move(other.m_reflectivities);
 
         return *this;
     }


### PR DESCRIPTION
## What does this PR do?

This PR build on top of #64, please see the description below:
```
This PR prepares branch with recent Lidar reflectivity changes.
It prepares the cherry-picked commits from feature/configurable-pc-message/alkam and feature/configurable-pc-message/reflectivity/alkam.

The picked commits are
-494b4f94c43eafa31f727fe80fccfa587bdd8475
-8b4f88179d59acb2928818e7fbf0ac1b4fa1c6b6
-f35c51ea21fce13175ef51956b214b56a113f1f3
```

The changes were not fully aligned with the data produced by some lidar sensors and the meaning of the `is_dense` field in the point cloud message. Before the last change, two parameters were available to the user: _dense_ and _ordered_. The first one would produce a compacted point cloud (without incorrect data), while the second would enforce sending all data. It was not clear what data is stored for all incorrect samples.

After changes in  a7af8beae15aa575fbb08da694df4c3272bec699 the following options are available:
- sending compacted point cloud (only valid samples)
- sending full point cloud, with invalid samples set to either zeros, or max range of the lidar, or infinity.
The UI is more consistent and self-explanatory. The `is_dense` flag in the point cloud message is set to true when all points in the stream are meaningful (this includes enforcing incorrect samples to a certain value) and the data's resolution is set correctly in the message's header.

## How was this PR tested?

It was tested using corresponding changes in `o3de-rgl-gem`
