### PR TITLE
Add service success setting in ROS2SpawnerComponent::GetAvailableSpawnableNames

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -70,8 +70,7 @@ ly_add_target(
             Gem::LmbrCentral.API
 )
 
-target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs vision_msgs)
-target_depends_on_ros2_package(${gem_name}.Static control_toolbox 2.2.0 REQUIRED)
+target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs vision_msgs control_msgs)
 
 ly_add_target(
     NAME ${gem_name}.API HEADERONLY

--- a/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include <control_toolbox/pid.hpp>
 
 namespace ROS2::Controllers
 {
-    //! A wrapper for ROS 2 control_toolbox pid controller.
+    //! A PID controller.
+    //! Based on a ROS 2 control_toolbox implementation.
     //! @see <a href="https://github.com/ros-controls/control_toolbox">control_toolbox</a>.
     class PidConfiguration
     {
@@ -38,7 +38,7 @@ namespace ROS2::Controllers
             const bool antiWindup,
             const double outputLimit);
 
-        //! Initialize PID using member fields as set by the user.
+        //! Initialize the controller
         void InitializePid();
 
         //! Compute the value of PID command.
@@ -54,8 +54,9 @@ namespace ROS2::Controllers
         double m_iMax = 10.0; //!< maximal allowable integral term.
         double m_iMin = -10.0; //!< minimal allowable integral term.
         bool m_antiWindup = false; //!< prevents condition of integrator overflow in integral action.
+        bool m_initialized = false; //!< is PID initialized.
         double m_outputLimit = 0.0; //!< limit PID output; set to 0.0 to disable.
-
-        control_toolbox::Pid m_pid; //!< PID implementation object from control_toolbox (of ros2_control).
+        double m_previousError = 0.0; //!< previous recorded error.
+        double m_integral = 0.0; //!< integral accumulator.
     };
 } // namespace ROS2::Controllers

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -175,7 +175,7 @@ namespace ROS2
 
     void CameraSensor::UpdateViewAlias()
     {
-        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
+        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessorInterface>())
         {
             const AZ::RPI::ViewPtr targetView = m_scene->GetDefaultRenderPipeline()->GetDefaultView();
             fp->SetViewAlias(m_view, targetView);

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -115,6 +115,7 @@ namespace ROS2
         {
             response->model_names.emplace_back(spawnable.first.c_str());
         }
+        response->success = true;
     }
 
     void ROS2SpawnerComponent::SpawnEntity(

--- a/Gems/ROS2/Code/Tests/PIDTest.cpp
+++ b/Gems/ROS2/Code/Tests/PIDTest.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+
+#include <ROS2/Utilities/Controllers/PidConfiguration.h>
+
+namespace UnitTest
+{
+    static const uint64_t secToNanosec = 1e9;
+
+    class PIDTest : public LeakDetectionFixture
+    {
+    };
+
+    TEST_F(PIDTest, iClampAntiwindup)
+    {
+        double iGain = 1.0;
+        double iMin = -1.0;
+        double iMax = 1.0;
+
+        ROS2::Controllers::PidConfiguration pid(0.0, iGain, 0.0, iMax, iMin, true, 1.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-10.0, 1 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(30.0, 1 * secToNanosec);
+        EXPECT_EQ(1.0, output);
+    }
+
+    TEST_F(PIDTest, iClampNoGain)
+    {
+        double iGain = 0.0;
+        double iMin = -1.0;
+        double iMax = 1.0;
+
+        ROS2::Controllers::PidConfiguration pid(0.0, iGain, 0.0, iMax, iMin, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_LE(iMin, output);
+        EXPECT_LE(output, iMax);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_LE(iMin, output);
+        EXPECT_LE(output, iMax);
+        EXPECT_EQ(0.0, output);
+    }
+
+    TEST_F(PIDTest, iAntiwindup)
+    {
+        double iGain = 2.0;
+        double iMin = -1.0;
+        double iMax = 1.0;
+
+        ROS2::Controllers::PidConfiguration pid(0.0, iGain, 0.0, iMax, iMin, true, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(0.5, 1 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+    }
+
+    TEST_F(PIDTest, negativeIAntiwindup)
+    {
+        double iGain = -2.5;
+        double iMin = -0.2;
+        double iMax = 0.5;
+
+        ROS2::Controllers::PidConfiguration pid(0.0, iGain, 0.0, iMax, iMin, true, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(0.1, 1 * secToNanosec);
+        EXPECT_EQ(-0.2, output);
+
+        output = pid.ComputeCommand(0.1, 1 * secToNanosec);
+        EXPECT_EQ(-0.2, output);
+
+        output = pid.ComputeCommand(-0.05, 1 * secToNanosec);
+        EXPECT_EQ(-0.075, output);
+
+        output = pid.ComputeCommand(0.1, 1 * secToNanosec);
+        EXPECT_EQ(-0.2, output);
+    }
+
+    TEST_F(PIDTest, pOnly)
+    {
+        ROS2::Controllers::PidConfiguration pid(1.0, 0.0, 0.0, 0.0, 0.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(0.5, 1 * secToNanosec);
+        EXPECT_EQ(0.5, output);
+    }
+
+    TEST_F(PIDTest, iOnly)
+    {
+        ROS2::Controllers::PidConfiguration pid(0.0, 1.0, 0.0, 5.0, -5.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(0.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(0.0, 1 * secToNanosec);
+        EXPECT_EQ(-1.0, output);
+
+        output = pid.ComputeCommand(1.0, 1 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+    }
+
+    TEST_F(PIDTest, dOnly)
+    {
+        ROS2::Controllers::PidConfiguration pid(0.0, 0.0, 1.0, 0.0, 0.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(-0.5, 0 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-0.5, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(0.5, output);
+    }
+
+    TEST_F(PIDTest, completePID)
+    {
+        ROS2::Controllers::PidConfiguration pid(1.0, 1.0, 1.0, 5.0, -5.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-1.5, output);
+
+        output = pid.ComputeCommand(-0.5, 1 * secToNanosec);
+        EXPECT_EQ(-1.5, output);
+
+        output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
+        EXPECT_EQ(-3.5, output);
+    }
+} // namespace UnitTest

--- a/Gems/ROS2/Code/ros2_tests_files.cmake
+++ b/Gems/ROS2/Code/ros2_tests_files.cmake
@@ -6,4 +6,5 @@
 set(FILES
     Tests/ROS2Test.cpp
     Tests/GNSSTest.cpp
+    Tests/PIDTest.cpp
 )


### PR DESCRIPTION
## What does this PR do?

The `/get_available_spawnable_names` service in `ROS2 Spawner` always returned `success=False` in response, while there were no issues in calling the service. This PR adds setting the `success` field to `true` in the appropriate method.

## How was this PR tested?

A scene with ROS2 Spawner was loaded and played in the editor and the service was called:

```
$ ros2 service call /get_available_spawnable_names gazebo_msgs/srv/GetWorldProperties
requester: making request: gazebo_msgs.srv.GetWorldProperties_Request()

response:
gazebo_msgs.srv.GetWorldProperties_Response(sim_time=0.0, model_names=['tomato', 'green_cube', 'apple', 'blue_cube', 'corn', 'toy_box', 'carrot', 'red_cube', 'yellow_cube'], rendering_enabled=False, success=True, status_message='')
```
