### PR TITLE
Rework frame - fixes to refactor + new features

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/NamespaceConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/NamespaceConfiguration.h
@@ -41,11 +41,7 @@ namespace ROS2
         //! Determine if namespace is using the Custom namespace strategy
         bool IsNamespaceCustom() const;
 
-        //! Update the namespace based on the current attributes
-        void UpdateNamespace();
-
         //! Helpers methods for UI
-        AZ::Crc32 OnNamespaceStrategySelected();
         AZ::Outcome<void, AZStd::string> ValidateNamespaceField(void* newValue, const AZ::Uuid& valueType);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
@@ -34,6 +35,7 @@ namespace ROS2
     class ROS2FrameComponent
         : public AZ::Component
         , public AZ::TickBus::Handler
+        , public ROS2FrameComponentBus::Handler
         , public ROSFrameInterface
     {
     public:
@@ -62,11 +64,12 @@ namespace ROS2
         //! Note that other won't be notified of the change.
         void EnablePublishingTransform();
 
-        const AZStd::string& GetNamespace() const;
-        const AZStd::string& GetNamespacedFrameID() const;
-        const AZStd::string& GetNamespacedJointName() const;
-        const AZStd::string& GetJointName() const;
-        const AZStd::string& GetFrameName() const;
+        AZStd::string GetNamespace() const override;
+        AZStd::string GetNamespacedFrameID() const override;
+        AZStd::string GetNamespacedJointName() const override;
+        AZStd::string GetJointName() const override;
+        AZStd::string GetFrameName() const override;
+        AZStd::string GetGlobalFrameName() const override;
 
         // ROSFrameInterface overrides
         ROS2FrameConfiguration GetConfiguration() const override;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -20,6 +20,12 @@
 namespace ROS2
 {
 
+    namespace
+    {
+        inline constexpr const char* DefaultGlobalFrameName = "odom";
+        inline constexpr const char* DefaultGlobalFrameNameConfigurationKey = "/O3DE/ROS2/DefaultGlobalFrameName";
+    } // namespace
+
     //! This component marks an interesting reference frame for ROS2 ecosystem.
     //! It serves as sensor data frame of reference and is responsible, through ROS2Transform, for publishing
     //! ros2 static and dynamic transforms (/tf_static, /tf). It also facilitates namespace handling.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -7,12 +7,12 @@
  */
 #pragma once
 
-#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include <ROS2/Frame/ROS2FrameComponentInterface.h>
 #include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <ROS2/Frame/ROS2Transform.h>

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponentBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponentBus.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+
+namespace ROS2
+{
+    class ROS2FrameComponentRequests : public AZ::ComponentBus
+    {
+    public:
+        // One handler per address is supported.
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        // The EBus has multiple addresses. Addresses are not ordered.
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+
+        // Messages are addressed by EntityId.
+        using BusIdType = AZ::EntityId;
+
+        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
+        //! @return A complete namespace (including parent namespaces)
+        virtual AZStd::string GetNamespace() const = 0;
+
+        //! Get a frame id, which is needed for any ROS2 message with a Header
+        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
+        virtual AZStd::string GetNamespacedFrameID() const = 0;
+
+        //! Get the joint name including the namespace
+        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
+        //! @return The namespaced joint name, ready to send in a ROS2 message
+        virtual AZStd::string GetNamespacedJointName() const = 0;
+
+        //! Get the joint name without namespace
+        //! @return The joint name without namespace prefix
+        virtual AZStd::string GetJointName() const = 0;
+
+        //! Get the frame name without namespace
+        //! @return The frame name without namespace prefix
+        virtual AZStd::string GetFrameName() const = 0;
+
+        //! Global frame name in ros2 ecosystem.
+        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
+        virtual AZStd::string GetGlobalFrameName() const = 0;
+    };
+
+    using ROS2FrameComponentBus = AZ::EBus<ROS2FrameComponentRequests>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponentBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponentBus.h
@@ -28,19 +28,6 @@ namespace ROS2
         // Messages are addressed by EntityId.
         using BusIdType = AZ::EntityId;
 
-        //! Get a frame id, which is needed for any ROS2 message with a Header
-        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        virtual AZStd::string GetNamespacedFrameID() const = 0;
-
-        //! Get the joint name including the namespace
-        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-        //! @return The namespaced joint name, ready to send in a ROS2 message
-        virtual AZ::Name GetNamespacedJointName() const = 0;
-
-        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-        //! @return A complete namespace (including parent namespaces)
-        virtual AZStd::string GetNamespace() const = 0;
-
         //! Find the parent frame of the entity.
         //! @return entityId of the parent frame or an invalid entityId if the frame is top level.
         virtual AZ::EntityId GetFrameParent() const = 0;
@@ -52,10 +39,6 @@ namespace ROS2
         //! Ask component to recompute its namespace based on the hierarchy and its configuration.
         //! called when some changes happen in the o3de transform tree or when configuration changes.
         virtual void UpdateNamespace() = 0;
-
-        //! Global frame name in ros2 ecosystem.
-        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        virtual AZStd::string GetGlobalFrameName() const = 0;
 
         //! Set the joint name (excluding namespace).
         //! @note May be populated during robot import.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameTrackingInterface.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameTrackingInterface.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/string/string.h>
+#include <ROS2/ROS2TypeIds.h>
+
+namespace ROS2
+{
+    //! Interface for querying and tracking ROS2 frame components in the system.
+    //! This interface provides access to the frame registry maintained by the ROS2FrameSystemComponent.
+    class ROS2FrameTrackingRequests
+    {
+    public:
+        AZ_RTTI(ROS2FrameTrackingRequests, ROS2FrameTrackingInterfaceTypeId);
+
+        //! Get all currently registered frame entities.
+        //! @return Set of EntityIds representing all registered frames
+        virtual const AZStd::unordered_set<AZ::EntityId>& GetRegisteredFrames() const = 0;
+
+        //! Check if a specific frame entity is registered.
+        //! @param frameEntityId The EntityId to check
+        //! @return True if the frame is registered, false otherwise
+        virtual bool IsFrameRegistered(const AZ::EntityId& frameEntityId) const = 0;
+
+        //! Get the number of registered frames.
+        //! @return Number of registered frame entities
+        virtual size_t GetRegisteredFrameCount() const = 0;
+
+        //! Get the entity ID for a frame with the given namespaced frame ID.
+        //! @param namespacedFrameId The namespaced frame ID to search for
+        //! @return EntityId of the frame, or invalid EntityId if not found
+        virtual AZStd::optional<AZ::EntityId> GetFrameEntityByNamespacedId(const AZStd::string& namespacedFrameId) const = 0;
+
+        //! Get the namespaced frame ID for a given entity.
+        //! @param frameEntityId The EntityId to get the namespaced frame ID for
+        //! @return The namespaced frame ID, or empty string if not found
+        virtual AZStd::optional<AZStd::string> GetNamespacedFrameId(const AZ::EntityId& frameEntityId) const = 0;
+
+        //! Get all namespaced frame IDs currently tracked.
+        //! @return Set of all namespaced frame IDs
+        virtual AZStd::unordered_set<AZStd::string> GetAllNamespacedFrameIds() const = 0;
+    };
+
+    using ROS2FrameTrackingInterface = AZ::Interface<ROS2FrameTrackingRequests>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/ROS2TypeIds.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2TypeIds.h
@@ -40,7 +40,9 @@ namespace ROS2
     inline constexpr const char* NamespaceConfigurationTypeId = "{5E5BC6EA-DD01-480E-A4D1-6857CF70FDC8}";
     inline constexpr const char* ROS2FrameComponentTypeId = "{AC74CBC1-A5DC-4014-85D7-0E7934F352BD}";
     inline constexpr const char* ROS2FrameConfigurationTypeId = "{04882F01-5451-4EFA-B4F8-CD57E4B6CADF}";
+    inline constexpr const char* ROS2FrameGameSystemComponentTypeId = "{76644841-EA20-40F8-A3F5-40F41A386C30}";
     inline constexpr const char* ROS2FrameEditorComponentTypeId = "{F76D6F29-73C3-40B2-BCC2-47FC824C25DF}";
+    inline constexpr const char* ROS2FrameTrackingInterfaceTypeId = "{6B262459-BA1B-4C6C-A9FF-C21D2841CCC1}";
 
     // Sensors Interface TypeIds
     inline constexpr const char* SensorConfigurationTypeId = "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}";

--- a/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
@@ -18,49 +18,48 @@
 namespace ROS2
 {
 
-        AZStd::string GetName(AZ::EntityId id)
+    AZStd::string GetName(AZ::EntityId id)
+    {
+        AZStd::string name;
+        AZ::ComponentApplicationBus::BroadcastResult(name, &AZ::ComponentApplicationRequests::GetEntityName, id);
+        return name;
+    }
+
+    AZStd::optional<ROS2FrameConfiguration> GetConfigurationFromComponent(AZ::EntityId id)
+    {
+        AZ::Entity* entity = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, id);
+        if (!entity)
         {
-            AZStd::string name;
-            AZ::ComponentApplicationBus::BroadcastResult(name, &AZ::ComponentApplicationRequests::GetEntityName, id);
-            return name;
+            return ROS2FrameConfiguration();
         }
-
-        AZStd::optional<ROS2FrameConfiguration> GetConfigurationFromComponent(AZ::EntityId id)
+        const auto* componentEditor = entity->FindComponent(AZ::Uuid(ROS2FrameEditorComponentTypeId));
+        if (componentEditor)
         {
-            AZ::Entity* entity = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, id);
-            if (!entity)
+            const auto* intreface = dynamic_cast<const ROSFrameInterface*>(componentEditor);
+            if (intreface)
             {
-                return ROS2FrameConfiguration();
+                return intreface->GetConfiguration();
             }
-            const auto* componentEditor = entity->FindComponent(AZ::Uuid(ROS2FrameEditorComponentTypeId));
-            if (componentEditor)
-            {
-                const auto* intreface = dynamic_cast<const ROSFrameInterface *>(componentEditor);
-                if (intreface)
-                {
-                    return intreface->GetConfiguration();
-                }
-            }
-            const auto* componentGame = entity->FindComponent(AZ::Uuid(ROS2FrameComponentTypeId));
-            if (componentGame)
-            {
-                const auto* intreface = dynamic_cast<const ROSFrameInterface *>(componentGame);
-                if (intreface)
-                {
-                    return intreface->GetConfiguration();
-                }
-            }
-            return AZStd::nullopt;
         }
+        const auto* componentGame = entity->FindComponent(AZ::Uuid(ROS2FrameComponentTypeId));
+        if (componentGame)
+        {
+            const auto* intreface = dynamic_cast<const ROSFrameInterface*>(componentGame);
+            if (intreface)
+            {
+                return intreface->GetConfiguration();
+            }
+        }
+        return AZStd::nullopt;
+    }
 
-
-        const AZStd::unordered_map<NamespaceConfiguration::NamespaceStrategy, AZStd::string_view> strategyToString = {
-            { NamespaceConfiguration::NamespaceStrategy::Default, "Default" },
-            { NamespaceConfiguration::NamespaceStrategy::Empty, "Empty" },
-            { NamespaceConfiguration::NamespaceStrategy::FromEntityName, "FromEntityName" },
-            { NamespaceConfiguration::NamespaceStrategy::Custom, "Custom" },
-        };
+    const AZStd::unordered_map<NamespaceConfiguration::NamespaceStrategy, AZStd::string_view> strategyToString = {
+        { NamespaceConfiguration::NamespaceStrategy::Default, "Default" },
+        { NamespaceConfiguration::NamespaceStrategy::Empty, "Empty" },
+        { NamespaceConfiguration::NamespaceStrategy::FromEntityName, "FromEntityName" },
+        { NamespaceConfiguration::NamespaceStrategy::Custom, "Custom" },
+    };
 
     bool HasROS2FrameComponent(AZ::EntityId id)
     {
@@ -88,17 +87,17 @@ namespace ROS2
         AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, id);
         if (!entity)
         {
-            return ;
+            return;
         }
         auto* transformInterface = entity->GetTransform();
         if (!transformInterface)
         {
-            return ;
+            return;
         }
         AZ::EntityId parentId = transformInterface->GetParentId();
         if (!parentId.IsValid())
         {
-            return ;
+            return;
         }
         TraverseTransforms(parentId, predecessors);
     }
@@ -164,117 +163,78 @@ namespace ROS2
 
     AZStd::string ComputeNamespace(const ROS2FrameConfiguration& configuration, AZ::EntityId entity, bool debug)
     {
-        if (configuration.m_namespaceConfiguration.m_namespaceStrategy == NamespaceConfiguration::NamespaceStrategy::Empty)
+        // Compute namespace based on ancestor frames.
+        const AZStd::vector<AZ::EntityId> predecessors = GetAllAncestorTransformBus(entity);
+        const AZStd::vector<AZ::EntityId> predecessorsWithRos2Frame = GetEntitiesWithROS2FrameComponent(predecessors);
+        const auto topLevelParentId = predecessorsWithRos2Frame.empty() ? AZ::EntityId() : predecessorsWithRos2Frame.back();
+        if (debug)
         {
-            return "";
-        }
-
-        // Non-empty and based on user-provided value.
-        if (configuration.m_namespaceConfiguration.m_namespaceStrategy == NamespaceConfiguration::NamespaceStrategy::Custom)
-        {
-            return configuration.m_namespaceConfiguration.m_customNamespace;
-        }
-
-        AZStd::string thisEntityName;
-
-        AZ::ComponentApplicationBus::BroadcastResult(thisEntityName, &AZ::ComponentApplicationRequests::GetEntityName, entity);
-        ROS2NamesRequestBus::BroadcastResult(thisEntityName, &ROS2NamesRequests::RosifyName, thisEntityName);
-
-        // Generate from Entity name, but substitute disallowed characters through RosifyName.
-        if (configuration.m_namespaceConfiguration.m_namespaceStrategy == NamespaceConfiguration::NamespaceStrategy::FromEntityName)
-        {
-            return thisEntityName;
-        }
-
-        // FromEntityName for top-level frames, Empty otherwise.
-        if (configuration.m_namespaceConfiguration.m_namespaceStrategy == NamespaceConfiguration::NamespaceStrategy::Default)
-        {
-            const AZStd::vector<AZ::EntityId> predecessors = GetAllAncestorTransformBus(entity);
-            const AZStd::vector<AZ::EntityId> predecessorsWithRos2Frame = GetEntitiesWithROS2FrameComponent(predecessors);
-            const auto topLevelParentId = predecessorsWithRos2Frame.empty() ? AZ::EntityId() : predecessorsWithRos2Frame.back();
-            if (debug)
+            // AZ_Printf("ROS2FrameSystemComponent::GetNamespace", "Resolving namespace for entity %s", thisEntityName.c_str());
+            for (auto it = predecessors.rbegin(); it != predecessors.rend(); ++it)
             {
-                AZ_Printf("ROS2FrameSystemComponent::GetNamespace", "Resolving namespace for entity %s", thisEntityName.c_str());
-                for (auto it = predecessors.rbegin(); it != predecessors.rend(); ++it)
+                const auto entityId = *it;
+                const auto thisFrameConfig = GetConfigurationFromComponent(entityId);
+                AZStd::string thisStrategyName = "No ROS2FrameComponent";
+                if (thisFrameConfig)
                 {
-                    const auto entityId = *it;
-                    const auto thisFrameConfig = GetConfigurationFromComponent(entityId);
-                    AZStd::string thisStrategyName = "No ROS2FrameComponent";
-                    if (thisFrameConfig)
-                    {
-                        thisStrategyName = strategyToString.at(thisFrameConfig->m_namespaceConfiguration.m_namespaceStrategy);
-                    }
-                    AZ_Printf(
-                        "ROS2FrameSystemComponent::GetNamespace",
-                        " - %s  [%s] %s",
-                        GetName(entityId).c_str(),
-                        thisStrategyName.c_str(),
-                        ((topLevelParentId == entityId) ? " (ros2 root frame)" : ""));
+                    thisStrategyName = strategyToString.at(thisFrameConfig->m_namespaceConfiguration.m_namespaceStrategy);
                 }
-            }
-            if (predecessorsWithRos2Frame.empty())
-            {
-                // No ROS2Frame components in ancestors, so we are top-level.
-                return thisEntityName;
-            }
-
-            const AZStd::string topLevelParentName = GetName(topLevelParentId);
-
-            AZStd::string resolvedName = "";
-            for (auto it = predecessorsWithRos2Frame.rbegin(); it != predecessorsWithRos2Frame.rend(); ++it)
-            {
-                const auto ancestorId = *it;
-                const auto ancestorConfig = GetConfigurationFromComponent(ancestorId);
-                if (!ancestorConfig)
-                {
-                    continue;
-                }
-                const auto ancestorStrategy = ancestorConfig->m_namespaceConfiguration.m_namespaceStrategy;
-                if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::FromEntityName)
-                {
-                    if (ancestorId == topLevelParentId)
-                    {
-                        resolvedName = GetName(ancestorId);
-                    }
-                    else
-                    {
-                        resolvedName += "/" + GetName(ancestorId);
-                    }
-                }
-                else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Custom)
-                {
-                    if (ancestorId == topLevelParentId)
-                    {
-                        resolvedName = ancestorConfig->m_namespaceConfiguration.m_customNamespace;
-                    }
-                    else
-                    {
-                        resolvedName += "/" + ancestorConfig->m_namespaceConfiguration.m_customNamespace;
-                    }
-                }
-                else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Empty)
-                {
-                    void(); // do nothing
-                }
-                else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Default)
-                {
-                    if (ancestorId == topLevelParentId)
-                    {
-                        resolvedName = GetName(ancestorId);
-                    }
-                }
-            }
-            if (debug)
-            {
                 AZ_Printf(
                     "ROS2FrameSystemComponent::GetNamespace",
-                    "Resolved namespace %s for entity %s",
-                    resolvedName.c_str(),
-                    thisEntityName.c_str());
+                    " - %s  [%s] %s",
+                    GetName(entityId).c_str(),
+                    thisStrategyName.c_str(),
+                    ((topLevelParentId == entityId) ? " (ros2 root frame)" : ""));
             }
-            return resolvedName;
         }
 
-        return "";
+        const AZStd::string topLevelParentName = GetName(topLevelParentId);
+
+        AZStd::string resolvedName = "";
+        for (auto it = predecessorsWithRos2Frame.rbegin(); it != predecessorsWithRos2Frame.rend(); ++it)
+        {
+            const auto ancestorId = *it;
+            const auto ancestorConfig = GetConfigurationFromComponent(ancestorId);
+            if (!ancestorConfig)
+            {
+                continue;
+            }
+            const auto ancestorStrategy = ancestorConfig->m_namespaceConfiguration.m_namespaceStrategy;
+            if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::FromEntityName)
+            {
+                if (ancestorId == topLevelParentId)
+                {
+                    resolvedName = GetName(ancestorId);
+                }
+                else
+                {
+                    resolvedName += "/" + GetName(ancestorId);
+                }
+            }
+            else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Custom)
+            {
+                if (ancestorId == topLevelParentId)
+                {
+                    resolvedName = ancestorConfig->m_namespaceConfiguration.m_customNamespace;
+                }
+                else
+                {
+                    resolvedName += "/" + ancestorConfig->m_namespaceConfiguration.m_customNamespace;
+                }
+            }
+            else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Empty)
+            {
+                void(); // do nothing
+            }
+            else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Default)
+            {
+                if (ancestorId == topLevelParentId)
+                {
+                    resolvedName = GetName(ancestorId);
+                }
+            }
+        }
+
+        return resolvedName;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
@@ -161,32 +161,12 @@ namespace ROS2
         return namespaceName + "/" + name;
     }
 
-    AZStd::string ComputeNamespace(const ROS2FrameConfiguration& configuration, AZ::EntityId entity, bool debug)
+    AZStd::string ComputeNamespace(const ROS2FrameConfiguration& configuration, AZ::EntityId entity)
     {
         // Compute namespace based on ancestor frames.
         const AZStd::vector<AZ::EntityId> predecessors = GetAllAncestorTransformBus(entity);
         const AZStd::vector<AZ::EntityId> predecessorsWithRos2Frame = GetEntitiesWithROS2FrameComponent(predecessors);
         const auto topLevelParentId = predecessorsWithRos2Frame.empty() ? AZ::EntityId() : predecessorsWithRos2Frame.back();
-        if (debug)
-        {
-            // AZ_Printf("ROS2FrameSystemComponent::GetNamespace", "Resolving namespace for entity %s", thisEntityName.c_str());
-            for (auto it = predecessors.rbegin(); it != predecessors.rend(); ++it)
-            {
-                const auto entityId = *it;
-                const auto thisFrameConfig = GetConfigurationFromComponent(entityId);
-                AZStd::string thisStrategyName = "No ROS2FrameComponent";
-                if (thisFrameConfig)
-                {
-                    thisStrategyName = strategyToString.at(thisFrameConfig->m_namespaceConfiguration.m_namespaceStrategy);
-                }
-                AZ_Printf(
-                    "ROS2FrameSystemComponent::GetNamespace",
-                    " - %s  [%s] %s",
-                    GetName(entityId).c_str(),
-                    thisStrategyName.c_str(),
-                    ((topLevelParentId == entityId) ? " (ros2 root frame)" : ""));
-            }
-        }
 
         const AZStd::string topLevelParentName = GetName(topLevelParentId);
 

--- a/Gems/ROS2/Code/Source/Frame/NamespaceComputation.h
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceComputation.h
@@ -16,7 +16,7 @@ namespace ROS2
 {
     //! This method computes the namespace for a given entity based on the provided configuration.
     //! It considers the namespace strategy defined in the configuration and the entity's position in the hierarchy
-    AZStd::string ComputeNamespace(const ROS2FrameConfiguration& configuration, AZ::EntityId entity, bool debug = false);
+    AZStd::string ComputeNamespace(const ROS2FrameConfiguration& configuration, AZ::EntityId entity);
 
     //! Gets the namespaced name for the given entity, combining its namespace and frame name.
     //! for empty namespace, it returns just the name

--- a/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
@@ -14,12 +14,6 @@
 namespace ROS2
 {
 
-
-    AZ::Crc32 NamespaceConfiguration::OnNamespaceStrategySelected()
-    {
-        return AZ::Edit::PropertyRefreshLevels::EntireTree;
-    }
-
     AZ::Outcome<void, AZStd::string> NamespaceConfiguration::ValidateNamespaceField(void* newValue, const AZ::Uuid& valueType)
     {
         AZ::Outcome<void, AZStd::string> outcome;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "NamespaceComputation.h"
+#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
@@ -108,6 +109,8 @@ namespace ROS2
             AZ::TickBus::Handler::BusConnect();
         }
 
+        ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
+
         if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
         {
             frameSystemInterface->RegisterFrame(GetEntityId());
@@ -120,6 +123,8 @@ namespace ROS2
         {
             frameSystemInterface->UnregisterFrame(GetEntityId());
         }
+
+        ROS2FrameComponentBus::Handler::BusDisconnect(GetEntityId());
 
         m_parentFrame.reset();
         m_sourceFrame.reset();
@@ -148,27 +153,8 @@ namespace ROS2
             else
             {
                 m_parentFrame = AZStd::nullopt;
-
-                // Get odometry frame, from settings registry
-                AZStd::string odometryFrame;
-                auto* registry = AZ::SettingsRegistry::Get();
-                AZ_Error("ROS2FrameComponent", registry, "No settings registry found, using default odometry frame name");
-                if (registry)
-                {
-                    if (!registry->Get(odometryFrame, DefaultGlobalFrameNameConfigurationKey))
-                    {
-                        odometryFrame = DefaultGlobalFrameName;
-                    }
-                }
-
-                if (m_computedNamespace.empty())
-                {
-                    m_sourceFrame = odometryFrame;
-                }
-                else
-                {
-                    m_sourceFrame = GetNamespacedName(m_computedNamespace, odometryFrame);
-                }
+                AZStd::string odometryFrame = GetGlobalFrameName();
+                m_sourceFrame = odometryFrame;
             }
         }
 
@@ -298,27 +284,27 @@ namespace ROS2
         AZ::TickBus::Handler::BusDisconnect();
     }
 
-    const AZStd::string& ROS2FrameComponent::GetNamespace() const
+    AZStd::string ROS2FrameComponent::GetNamespace() const
     {
         return m_computedNamespace;
     }
 
-    const AZStd::string& ROS2FrameComponent::GetNamespacedFrameID() const
+    AZStd::string ROS2FrameComponent::GetNamespacedFrameID() const
     {
         return m_computedFrameName;
     }
 
-    const AZStd::string& ROS2FrameComponent::GetNamespacedJointName() const
+    AZStd::string ROS2FrameComponent::GetNamespacedJointName() const
     {
         return m_computedJointName;
     }
 
-    const AZStd::string& ROS2FrameComponent::GetJointName() const
+    AZStd::string ROS2FrameComponent::GetJointName() const
     {
         return m_configuration.m_jointName;
     }
 
-    const AZStd::string& ROS2FrameComponent::GetFrameName() const
+    AZStd::string ROS2FrameComponent::GetFrameName() const
     {
         return m_configuration.m_frameName;
     }
@@ -335,6 +321,21 @@ namespace ROS2
             AZ_Assert(GetEntity()->GetState() != AZ::Entity::State::Active, "API can be called only for disabled components");
         }
         m_configuration = config;
+    }
+
+    AZStd::string ROS2FrameComponent::GetGlobalFrameName() const
+    {
+        AZStd::string odometryFrame;
+        auto* registry = AZ::SettingsRegistry::Get();
+        AZ_Error("ROS2FrameComponent", registry, "No settings registry found, using default odometry frame name");
+        if (registry)
+        {
+            if (!registry->Get(odometryFrame, DefaultGlobalFrameNameConfigurationKey))
+            {
+                odometryFrame = DefaultGlobalFrameName;
+            }
+        }
+        return GetNamespacedName(m_computedNamespace, odometryFrame);
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -118,7 +118,7 @@ namespace ROS2
 
     void ROS2FrameComponent::ComputeNamespaceAndFrameName()
     {
-        m_computedNamespace = ComputeNamespace(m_configuration, GetEntityId(), true);
+        m_computedNamespace = ComputeNamespace(m_configuration, GetEntityId());
         m_computedFrameName = GetNamespacedName(m_computedNamespace, m_configuration.m_frameName);
         m_computedJointName = GetNamespacedName(m_computedNamespace, m_configuration.m_jointName);
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -16,12 +16,14 @@
 #include <AzCore/Serialization/Json/JsonSerializationResult.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2NamesBus.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
+
 namespace ROS2
 {
 
@@ -80,11 +82,11 @@ namespace ROS2
                 return true;
             }
             const bool hasJoints =
-                               Internal::HasComponentOfType(entity, AZ::Uuid("{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}")); // PhysX::JointComponent;
-            const bool hasFixedJoints = Internal::HasComponentOfType(
-                entity, AZ::Uuid("{02E6C633-8F44-4CEE-AE94-DCB06DE36422}")); // PhysX::FixedJointComponent
-            const bool hasArticulations = Internal::HasComponentOfType(
-                entity, AZ::Uuid("{48751E98-B35F-4A2F-A908-D9CDD5230264}")); // PhysX::ArticulationComponent
+                Internal::HasComponentOfType(entity, AZ::Uuid("{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}")); // PhysX::JointComponent;
+            const bool hasFixedJoints =
+                Internal::HasComponentOfType(entity, AZ::Uuid("{02E6C633-8F44-4CEE-AE94-DCB06DE36422}")); // PhysX::FixedJointComponent
+            const bool hasArticulations =
+                Internal::HasComponentOfType(entity, AZ::Uuid("{48751E98-B35F-4A2F-A908-D9CDD5230264}")); // PhysX::ArticulationComponent
             return (hasJoints && !hasFixedJoints) || hasArticulations;
         }
 
@@ -92,7 +94,6 @@ namespace ROS2
 
     void ROS2FrameComponent::Init()
     {
-        // m_namespaceConfiguration.Init();
     }
 
     void ROS2FrameComponent::Activate()
@@ -136,8 +137,19 @@ namespace ROS2
             else
             {
                 m_parentFrame = AZStd::nullopt;
-                // TODO (mpelka) get this global frame from set reg
-                constexpr char odometryFrame[] = "odom";
+
+                // Get odometry frame, from settings registry
+                AZStd::string odometryFrame;
+                auto* registry = AZ::SettingsRegistry::Get();
+                AZ_Error("ROS2FrameComponent", registry, "No settings registry found, using default odometry frame name");
+                if (registry)
+                {
+                    if (!registry->Get(odometryFrame, DefaultGlobalFrameNameConfigurationKey))
+                    {
+                        odometryFrame = DefaultGlobalFrameName;
+                    }
+                }
+
                 if (m_computedNamespace.empty())
                 {
                     m_sourceFrame = odometryFrame;
@@ -159,8 +171,13 @@ namespace ROS2
         if (m_ros2Transform == nullptr && m_sourceFrame.has_value())
         {
             const bool isTopLevel = !m_parentFrame.has_value();
-            const bool dynamic = m_configuration.m_forceDynamic || Internal::IsDynamicHeuristic(isTopLevel, GetEntity()) ;
-            AZ_Printf("m_ros2Transform", "publishing transform from %s to %s, type %s", m_sourceFrame->c_str(), GetNamespacedFrameID().c_str(), dynamic? "dynamic":"static" );
+            const bool dynamic = m_configuration.m_forceDynamic || Internal::IsDynamicHeuristic(isTopLevel, GetEntity());
+            AZ_Printf(
+                "m_ros2Transform",
+                "publishing transform from %s to %s, type %s",
+                m_sourceFrame->c_str(),
+                GetNamespacedFrameID().c_str(),
+                dynamic ? "dynamic" : "static");
 
             m_ros2Transform = AZStd::make_unique<ROS2Transform>(*m_sourceFrame, GetNamespacedFrameID(), dynamic);
             m_ros2Transform->Publish(GetFrameTransform());
@@ -240,7 +257,7 @@ namespace ROS2
         required.push_back(AZ_CRC_CE("TransformService"));
     }
 
-    ROS2FrameComponent::ROS2FrameComponent() {};
+    ROS2FrameComponent::ROS2FrameComponent(){};
 
     ROS2FrameComponent::ROS2FrameComponent(const ROS2FrameConfiguration& ros2FrameConfiguration)
         : m_configuration(ros2FrameConfiguration)

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "NamespaceComputation.h"
+#include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
 #include <AzCore/RTTI/ReflectContext.h>
@@ -106,10 +107,20 @@ namespace ROS2
         {
             AZ::TickBus::Handler::BusConnect();
         }
+
+        if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
+        {
+            frameSystemInterface->RegisterFrame(GetEntityId());
+        }
     }
 
     void ROS2FrameComponent::Deactivate()
     {
+        if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
+        {
+            frameSystemInterface->UnregisterFrame(GetEntityId());
+        }
+
         m_parentFrame.reset();
         m_sourceFrame.reset();
         m_ros2Transform.reset();

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "NamespaceComputation.h"
-#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
@@ -20,6 +19,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2NamesBus.h>

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -61,7 +61,6 @@ namespace ROS2
 
     AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
     {
-        const auto name_space = ComputeNamespace(m_configuration, GetEntityId());
         // Get odometry frame, from settings registry
         AZStd::string odometryFrame;
         auto* registry = AZ::SettingsRegistry::Get();
@@ -73,6 +72,9 @@ namespace ROS2
                 odometryFrame = DefaultGlobalFrameName;
             }
         }
+
+        const auto name_space = ComputeNamespace(m_configuration, GetEntityId());
+
         return GetNamespacedName(name_space, odometryFrame);
     }
 
@@ -167,7 +169,7 @@ namespace ROS2
 
     AZ::Crc32 ROS2FrameEditorComponent::OnFrameConfigurationChange()
     {
-        m_effectiveNamespace = ComputeNamespace(m_configuration, GetEntityId(), true);
+        m_effectiveNamespace = ComputeNamespace(m_configuration, GetEntityId());
         m_fullName = GetNamespacedName(m_effectiveNamespace, m_configuration.m_frameName);
         return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -8,7 +8,6 @@
 
 #include "ROS2FrameEditorComponent.h"
 #include "NamespaceComputation.h"
-#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
@@ -22,6 +21,7 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include <ROS2/Frame/ROS2FrameEditorComponentBus.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2NamesBus.h>

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -7,33 +7,33 @@
  */
 
 #include "ROS2FrameEditorComponent.h"
+#include "NamespaceComputation.h"
 #include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/EntityUtils.h>
+#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Frame/ROS2FrameEditorComponentBus.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2NamesBus.h>
-#include <AzCore/Component/TransformBus.h>
-#include "NamespaceComputation.h"
+
 namespace ROS2
 {
     ROS2FrameEditorComponent::ROS2FrameEditorComponent(const ROS2FrameConfiguration ros2FrameConfiguration)
     {
-
         m_configuration = ros2FrameConfiguration;
     }
 
     void ROS2FrameEditorComponent::Init()
     {
-
     }
 
     void ROS2FrameEditorComponent::Activate()
@@ -62,8 +62,18 @@ namespace ROS2
     AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
     {
         const auto name_space = ComputeNamespace(m_configuration, GetEntityId());
-        //TODO mpelka - get this global frame from set reg
-        return GetNamespacedName(name_space, "odom");
+        // Get odometry frame, from settings registry
+        AZStd::string odometryFrame;
+        auto* registry = AZ::SettingsRegistry::Get();
+        AZ_Error("ROS2FrameComponent", registry, "No settings registry found, using default odometry frame name");
+        if (registry)
+        {
+            if (!registry->Get(odometryFrame, DefaultGlobalFrameNameConfigurationKey))
+            {
+                odometryFrame = DefaultGlobalFrameName;
+            }
+        }
+        return GetNamespacedName(name_space, odometryFrame);
     }
 
     bool ROS2FrameEditorComponent::IsTopLevel() const
@@ -92,7 +102,6 @@ namespace ROS2
 
         AzToolsFramework::PropertyEditorEntityChangeNotificationBus::Event(
             GetEntityId(), &AzToolsFramework::PropertyEditorEntityChangeNotificationBus::Events::OnEntityComponentPropertyChanged, GetId());
-
     }
 
     AZ::Name ROS2FrameEditorComponent::GetNamespacedJointName() const
@@ -136,7 +145,6 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameEditorComponent::m_effectiveNamespace)
                     ->UIElement(AZ::Edit::UIHandlers::Label, "Full name", "")
                     ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameEditorComponent::m_fullName);
-
             }
         }
     }
@@ -199,6 +207,5 @@ namespace ROS2
         AZ_Assert(GetEntity()->GetState() != AZ::Entity::State::Active, "API can be called only for disabled components");
         m_configuration = config;
     }
-
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -8,6 +8,7 @@
 
 #include "ROS2FrameEditorComponent.h"
 #include "NamespaceComputation.h"
+#include "ROS2/Frame/ROS2FrameComponentBus.h"
 #include "ROS2FrameSystemBus.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
@@ -46,11 +47,14 @@ namespace ROS2
             frameSystemInterface->RegisterFrame(GetEntityId());
         }
         UpdateNamespace();
+
+        ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
     }
 
     void ROS2FrameEditorComponent::Deactivate()
     {
-        AZ_Printf("BuildGameEntity", "ROS2FrameEditorComponent::Deactivate for entity %s", this->GetEntityId().ToString().c_str());
+        ROS2FrameComponentBus::Handler::BusDisconnect();
+
         if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
         {
             frameSystemInterface->UnregisterFrame(GetEntityId());
@@ -106,10 +110,10 @@ namespace ROS2
             GetEntityId(), &AzToolsFramework::PropertyEditorEntityChangeNotificationBus::Events::OnEntityComponentPropertyChanged, GetId());
     }
 
-    AZ::Name ROS2FrameEditorComponent::GetNamespacedJointName() const
+    AZStd::string ROS2FrameEditorComponent::GetNamespacedJointName() const
     {
         auto name_space = ComputeNamespace(m_configuration, GetEntityId());
-        return AZ::Name(GetNamespacedName(name_space, m_configuration.m_jointName));
+        return GetNamespacedName(name_space, m_configuration.m_jointName);
     }
 
     void ROS2FrameEditorComponent::SetJointName(const AZStd::string& jointName)
@@ -208,6 +212,16 @@ namespace ROS2
     {
         AZ_Assert(GetEntity()->GetState() != AZ::Entity::State::Active, "API can be called only for disabled components");
         m_configuration = config;
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetJointName() const
+    {
+        return m_configuration.m_jointName;
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetFrameName() const
+    {
+        return m_configuration.m_frameName;
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include <ROS2/Frame/ROS2FrameComponentInterface.h>
 #include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <ROS2/Frame/ROS2FrameEditorComponentBus.h>
@@ -26,6 +27,7 @@ namespace ROS2
     class ROS2FrameEditorComponent
         : public AzToolsFramework::Components::EditorComponentBase
         , public ROS2FrameEditorComponentBus::Handler
+        , public ROS2FrameComponentBus::Handler
         , public AZ::EntityBus::Handler
         , public ROSFrameInterface
     {
@@ -55,8 +57,10 @@ namespace ROS2
     private:
         // ROS2FrameEditorComponentBus::Handler overrides
         AZStd::string GetNamespacedFrameID() const override;
-        AZ::Name GetNamespacedJointName() const override;
+        AZStd::string GetNamespacedJointName() const override;
         AZStd::string GetNamespace() const override;
+        AZStd::string GetJointName() const override;
+        AZStd::string GetFrameName() const override;
         void UpdateNamespace() override;
         AZStd::string GetGlobalFrameName() const override;
         bool IsTopLevel() const override; //!< True if this entity does not have a parent entity with ROS2.

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
@@ -11,10 +11,10 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <ROS2/Frame/ROS2FrameComponentInterface.h>
 #include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <ROS2/Frame/ROS2FrameEditorComponentBus.h>
 #include <ROS2/ROS2TypeIds.h>
-#include <ROS2/Frame/ROS2FrameComponentInterface.h>
 
 namespace ROS2
 {
@@ -30,7 +30,8 @@ namespace ROS2
         , public ROSFrameInterface
     {
     public:
-        AZ_EDITOR_COMPONENT(ROS2FrameEditorComponent, ROS2FrameEditorComponentTypeId, AzToolsFramework::Components::EditorComponentBase, ROSFrameInterface);
+        AZ_EDITOR_COMPONENT(
+            ROS2FrameEditorComponent, ROS2FrameEditorComponentTypeId, AzToolsFramework::Components::EditorComponentBase, ROSFrameInterface);
 
         ROS2FrameEditorComponent() = default;
         ~ROS2FrameEditorComponent() = default;
@@ -46,7 +47,6 @@ namespace ROS2
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-
 
         // ROSFrameInterface overrides
         ROS2FrameConfiguration GetConfiguration() const override;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.cpp
@@ -27,19 +27,8 @@ namespace ROS2
 {
 
     ROS2FrameEditorSystemComponent::ROS2FrameEditorSystemComponent()
+        : ROS2FrameGameSystemComponent()
     {
-        if (ROS2FrameSystemInterface::Get() == nullptr)
-        {
-            ROS2FrameSystemInterface::Register(this);
-        }
-    }
-
-    ROS2FrameEditorSystemComponent::~ROS2FrameEditorSystemComponent()
-    {
-        if (ROS2FrameSystemInterface::Get() == this)
-        {
-            ROS2FrameSystemInterface::Unregister(this);
-        }
     }
 
     void ROS2FrameEditorSystemComponent::Reflect(AZ::ReflectContext* context)
@@ -53,7 +42,7 @@ namespace ROS2
 
     void ROS2FrameEditorSystemComponent::Activate()
     {
-        AZ_Printf("ROS2FrameSystemComponent", "Activating ROS2FrameSystemComponent");
+        ROS2FrameGameSystemComponent::Activate();
     }
 
     void ROS2FrameEditorSystemComponent::Deactivate()
@@ -63,12 +52,14 @@ namespace ROS2
             AZ::TransformNotificationBus::MultiHandler::BusDisconnect(id);
             AzToolsFramework::EntitySelectionEvents::Bus::MultiHandler::BusDisconnect(id);
         }
-        m_registeredEntities.clear();
+
+        ROS2FrameGameSystemComponent::Deactivate();
     }
 
     void ROS2FrameEditorSystemComponent::RegisterFrame(const AZ::EntityId& frameToRegister)
     {
-        m_registeredEntities.insert(frameToRegister);
+        ROS2FrameGameSystemComponent::RegisterFrame(frameToRegister);
+
         AzToolsFramework::EntitySelectionEvents::Bus::MultiHandler::BusConnect(frameToRegister);
         AZ::TransformNotificationBus::MultiHandler::BusConnect(frameToRegister);
     }
@@ -77,7 +68,8 @@ namespace ROS2
     {
         AZ::TransformNotificationBus::MultiHandler::BusDisconnect(frameToUnregister);
         AzToolsFramework::EntitySelectionEvents::Bus::MultiHandler::BusDisconnect(frameToUnregister);
-        m_registeredEntities.erase(frameToUnregister);
+
+        ROS2FrameGameSystemComponent::UnregisterFrame(frameToUnregister);
     }
 
     void ROS2FrameEditorSystemComponent::OnSelected()

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.h
@@ -10,6 +10,7 @@
 #include "AzCore/Component/TickBus.h"
 #include "ROS2FrameSystemBus.h"
 
+#include "ROS2FrameGameSystemComponent.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityId.h>
@@ -30,22 +31,21 @@ namespace ROS2
     //! It also notifies the ROS2FrameEditorComponent about changes in the tree.
     //! Used to register, unregister, track the frame entities in the level entity tree.
     class ROS2FrameEditorSystemComponent
-        : public AZ::Component
-        , protected ROS2FrameSystemInterface::Registrar
+        : public ROS2FrameGameSystemComponent
         , protected AzToolsFramework::EntitySelectionEvents::Bus::MultiHandler
         , protected AZ::TransformNotificationBus::MultiHandler
     {
     public:
         AZ_COMPONENT(ROS2FrameEditorSystemComponent, "{360c4b45-ac02-42d2-9e1a-1d77eb22a054}");
+
+        ROS2FrameEditorSystemComponent();
+        ~ROS2FrameEditorSystemComponent() = default;
+
         static void Reflect(AZ::ReflectContext* context);
 
         // AZ::Component overrides.
         void Activate() override;
         void Deactivate() override;
-
-        ROS2FrameEditorSystemComponent();
-
-        ~ROS2FrameEditorSystemComponent();
 
     private:
         // ROS2FrameSystemInterface::Registrar overrides.

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorSystemComponent.h
@@ -19,8 +19,8 @@
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
-#include <ROS2/Frame/ROS2FrameConfiguration.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <ROS2/Frame/ROS2FrameConfiguration.h>
 
 namespace ROS2
 {
@@ -58,8 +58,5 @@ namespace ROS2
         void OnParentChanged(AZ::EntityId oldParent, AZ::EntityId newParent) override;
 
         AZStd::set<AZ::EntityId> m_registeredEntities; //!< Set of all registered frame entities.
-
-
-
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/std/ranges/elements_view.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 
 namespace ROS2
 {
@@ -61,18 +62,12 @@ namespace ROS2
     {
         m_registeredEntities.insert(frameEntityId);
 
-        // FIXME: Temporary finding of ROS2 Frame Component, this should be done using an EBus
-        AZ::Entity* entity = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, frameEntityId);
-        if (entity)
+        AZStd::string namespaceFrameId = "";
+        ROS2FrameComponentBus::EventResult(namespaceFrameId, frameEntityId, &ROS2FrameComponentBus::Events::GetNamespace);
+        if (!namespaceFrameId.empty())
         {
-            auto* frameComponent = entity->FindComponent<ROS2FrameComponent>();
-            if (frameComponent)
-            {
-                AZStd::string namespacedFrameId = frameComponent->GetNamespacedFrameID();
-                m_entityIdToFrameId[frameEntityId] = namespacedFrameId;
-                m_frameIdToEntityId[namespacedFrameId] = frameEntityId;
-            }
+            m_frameIdToEntityId[namespaceFrameId] = frameEntityId;
+            m_entityIdToFrameId[frameEntityId] = namespaceFrameId;
         }
     }
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2FrameGameSystemComponent.h"
+#include <AzCore/std/ranges/elements_view.h>
+
+namespace ROS2
+{
+
+    ROS2FrameGameSystemComponent::ROS2FrameGameSystemComponent()
+    {
+        if (ROS2FrameSystemInterface::Get() == nullptr)
+        {
+            ROS2FrameSystemInterface::Register(this);
+        }
+        if (ROS2FrameTrackingInterface::Get() == nullptr)
+        {
+            ROS2FrameTrackingInterface::Register(this);
+        }
+    }
+
+    ROS2FrameGameSystemComponent::~ROS2FrameGameSystemComponent()
+    {
+        if (ROS2FrameSystemInterface::Get() == this)
+        {
+            ROS2FrameSystemInterface::Unregister(this);
+        }
+        if (ROS2FrameTrackingInterface::Get() == this)
+        {
+            ROS2FrameTrackingInterface::Unregister(this);
+        }
+    }
+
+    void ROS2FrameGameSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2FrameGameSystemComponent, AZ::Component>()->Version(1);
+        }
+    }
+
+    void ROS2FrameGameSystemComponent::Activate()
+    {
+    }
+
+    void ROS2FrameGameSystemComponent::Deactivate()
+    {
+        m_registeredEntities.clear();
+        m_entityIdToFrameId.clear();
+        m_frameIdToEntityId.clear();
+    }
+
+    void ROS2FrameGameSystemComponent::RegisterFrame(const AZ::EntityId& frameEntityId)
+    {
+        m_registeredEntities.insert(frameEntityId);
+        // TODO register frame ID mapping
+    }
+
+    void ROS2FrameGameSystemComponent::UnregisterFrame(const AZ::EntityId& frameEntityId)
+    {
+        m_registeredEntities.erase(frameEntityId);
+        m_entityIdToFrameId.erase(frameEntityId);
+        // TODO unregister frame ID mapping
+    }
+
+    const AZStd::unordered_set<AZ::EntityId>& ROS2FrameGameSystemComponent::GetRegisteredFrames() const
+    {
+        return m_registeredEntities;
+    }
+
+    bool ROS2FrameGameSystemComponent::IsFrameRegistered(const AZ::EntityId& frameEntityId) const
+    {
+        return m_registeredEntities.find(frameEntityId) != m_registeredEntities.end();
+    }
+
+    size_t ROS2FrameGameSystemComponent::GetRegisteredFrameCount() const
+    {
+        return m_registeredEntities.size();
+    }
+
+    AZStd::optional<AZ::EntityId> ROS2FrameGameSystemComponent::GetFrameEntityByNamespacedId(const AZStd::string& namespacedFrameId) const
+    {
+        auto it = m_frameIdToEntityId.find(namespacedFrameId);
+        return (it != m_frameIdToEntityId.end()) ? AZStd::optional<AZ::EntityId>(it->second) : AZStd::nullopt;
+    }
+
+    AZStd::optional<AZStd::string> ROS2FrameGameSystemComponent::GetNamespacedFrameId(const AZ::EntityId& frameEntityId) const
+    {
+        auto it = m_entityIdToFrameId.find(frameEntityId);
+        return (it != m_entityIdToFrameId.end()) ? AZStd::optional<AZStd::string>(it->second) : AZStd::nullopt;
+    }
+
+    AZStd::unordered_set<AZStd::string> ROS2FrameGameSystemComponent::GetAllNamespacedFrameIds() const
+    {
+        AZStd::unordered_set<AZStd::string> frameIds;
+        AZStd::ranges::transform(
+            m_entityIdToFrameId | AZStd::views::values,
+            AZStd::inserter(frameIds, frameIds.end()),
+            [](const auto& frameId)
+            {
+                return frameId;
+            });
+
+        return frameIds;
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
@@ -63,7 +63,7 @@ namespace ROS2
         m_registeredEntities.insert(frameEntityId);
 
         AZStd::string namespaceFrameId = "";
-        ROS2FrameComponentBus::EventResult(namespaceFrameId, frameEntityId, &ROS2FrameComponentBus::Events::GetNamespace);
+        ROS2FrameComponentBus::EventResult(namespaceFrameId, frameEntityId, &ROS2FrameComponentBus::Events::GetNamespacedFrameID);
         if (!namespaceFrameId.empty())
         {
             m_frameIdToEntityId[namespaceFrameId] = frameEntityId;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "ROS2FrameGameSystemComponent.h"
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/std/ranges/elements_view.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
 
 namespace ROS2
 {
@@ -58,14 +60,28 @@ namespace ROS2
     void ROS2FrameGameSystemComponent::RegisterFrame(const AZ::EntityId& frameEntityId)
     {
         m_registeredEntities.insert(frameEntityId);
-        // TODO register frame ID mapping
+
+        // FIXME: Temporary finding of ROS2 Frame Component, this should be done using an EBus
+        AZ::Entity* entity = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, frameEntityId);
+        if (entity)
+        {
+            auto* frameComponent = entity->FindComponent<ROS2FrameComponent>();
+            if (frameComponent)
+            {
+                AZStd::string namespacedFrameId = frameComponent->GetNamespacedFrameID();
+                m_entityIdToFrameId[frameEntityId] = namespacedFrameId;
+                m_frameIdToEntityId[namespacedFrameId] = frameEntityId;
+            }
+        }
     }
 
     void ROS2FrameGameSystemComponent::UnregisterFrame(const AZ::EntityId& frameEntityId)
     {
         m_registeredEntities.erase(frameEntityId);
+        AZStd::string namespacedFrameId = m_entityIdToFrameId[frameEntityId];
+        m_frameIdToEntityId.erase(namespacedFrameId);
         m_entityIdToFrameId.erase(frameEntityId);
-        // TODO unregister frame ID mapping
     }
 
     const AZStd::unordered_set<AZ::EntityId>& ROS2FrameGameSystemComponent::GetRegisteredFrames() const

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameGameSystemComponent.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "AzCore/Component/EntityId.h"
+#include "ROS2FrameSystemBus.h"
+
+#include <AzCore/Component/Component.h>
+#include <ROS2/Frame/ROS2FrameTrackingInterface.h>
+#include <ROS2/ROS2TypeIds.h>
+
+namespace ROS2
+{
+    class ROS2FrameGameSystemComponent
+        : public AZ::Component
+        , protected ROS2FrameSystemInterface::Registrar
+        , protected ROS2FrameTrackingInterface::Registrar
+    {
+    public:
+        AZ_COMPONENT(ROS2FrameGameSystemComponent, ROS2FrameGameSystemComponentTypeId);
+
+        ROS2FrameGameSystemComponent();
+        ~ROS2FrameGameSystemComponent();
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void Activate() override;
+        void Deactivate() override;
+
+    protected:
+        // ROS2FrameSystemInterface::Registrar
+        void RegisterFrame(const AZ::EntityId& frameEntityId) override;
+        void UnregisterFrame(const AZ::EntityId& frameEntityId) override;
+
+        // ROS2FrameTrackingInterface::Registrar
+        const AZStd::unordered_set<AZ::EntityId>& GetRegisteredFrames() const override;
+        bool IsFrameRegistered(const AZ::EntityId& frameEntityId) const override;
+        size_t GetRegisteredFrameCount() const override;
+        AZStd::optional<AZ::EntityId> GetFrameEntityByNamespacedId(const AZStd::string& namespacedFrameId) const override;
+        AZStd::optional<AZStd::string> GetNamespacedFrameId(const AZ::EntityId& frameEntityId) const override;
+        AZStd::unordered_set<AZStd::string> GetAllNamespacedFrameIds() const override;
+
+        AZStd::unordered_set<AZ::EntityId> m_registeredEntities; //!< Set of all registered frame entities.
+
+        AZStd::map<AZ::EntityId, AZStd::string> m_entityIdToFrameId;
+        AZStd::map<AZStd::string, AZ::EntityId> m_frameIdToEntityId;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemBus.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemBus.h
@@ -33,7 +33,6 @@ namespace ROS2
         //! unregister using this function during deactivation.
         //! @param frameEntityId entityId containing the frame to unregister.
         virtual void UnregisterFrame(const AZ::EntityId& frameEntityId) = 0;
-
     };
 
     class ROS2FrameSystemBusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.cpp
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.cpp
@@ -11,6 +11,7 @@
 
 #include <Clients/ROS2SystemComponent.h>
 #include <Clock/ROS2ClockSystemComponent.h>
+#include <Frame/ROS2FrameGameSystemComponent.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2TypeIds.h>
 #include <ROS2/Sensor/Events/PhysicsBasedSource.h>
@@ -33,6 +34,7 @@ namespace ROS2
         m_descriptors.insert(
             m_descriptors.end(),
             {
+                ROS2FrameGameSystemComponent::CreateDescriptor(),
                 ROS2SystemComponent::CreateDescriptor(),
                 ROS2ClockSystemComponent::CreateDescriptor(),
                 ROS2FrameComponent::CreateDescriptor(),
@@ -48,8 +50,8 @@ namespace ROS2
 
     AZ::ComponentTypeList ROS2ModuleInterface::GetRequiredSystemComponents() const
     {
-        return AZ::ComponentTypeList{
-            azrtti_typeid<ROS2SystemComponent>(), azrtti_typeid<ROS2ClockSystemComponent>()
-        };
+        return AZ::ComponentTypeList{ azrtti_typeid<ROS2SystemComponent>(),
+                                      azrtti_typeid<ROS2ClockSystemComponent>(),
+                                      azrtti_typeid<ROS2FrameGameSystemComponent>() };
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -301,8 +301,10 @@ namespace ROS2
                 entity->SetName(instanceName);
                 if (!spawnableNamespace.empty())
                 {
-                    // TODO Mpelka - fix
-                    //frameComponent->UpdateNamespaceConfiguration(spawnableNamespace, NamespaceConfiguration::NamespaceStrategy::Custom);
+                    auto configuration = frameComponent->GetConfiguration();
+                    configuration.m_namespaceConfiguration.m_customNamespace = spawnableNamespace;
+                    configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Custom;
+                    frameComponent->SetConfiguration(configuration);
                 }
                 break;
             }

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -7,6 +7,7 @@
  *
  */
 
+#include "Frame/ROS2FrameGameSystemComponent.h"
 #include <AzCore/Asset/AssetManagerComponent.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
@@ -26,6 +27,8 @@
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
 #include <Clients/ROS2SystemComponent.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
+#include <ROS2/Frame/ROS2FrameTrackingInterface.h>
 #include <ROS2/ROS2Bus.h>
 
 #include <QApplication>
@@ -53,9 +56,12 @@ namespace UnitTest
     {
         AddActiveGems(AZStd::to_array<AZStd::string_view>({ "ROS2" }));
         AddDynamicModulePaths({});
-        AddComponentDescriptors(AZStd::initializer_list<AZ::ComponentDescriptor*>{ ROS2::ROS2FrameComponent::CreateDescriptor(),
-                                                                                   ROS2::ROS2SystemComponent::CreateDescriptor() });
-        AddRequiredComponents(AZStd::to_array<AZ::TypeId const>({ ROS2::ROS2SystemComponent::TYPEINFO_Uuid() }));
+        AddComponentDescriptors(
+            AZStd::initializer_list<AZ::ComponentDescriptor*>{ ROS2::ROS2FrameComponent::CreateDescriptor(),
+                                                               ROS2::ROS2SystemComponent::CreateDescriptor(),
+                                                               ROS2::ROS2FrameGameSystemComponent::CreateDescriptor() });
+        AddRequiredComponents(AZStd::to_array<AZ::TypeId const>(
+            { ROS2::ROS2SystemComponent::TYPEINFO_Uuid(), ROS2::ROS2FrameGameSystemComponent::TYPEINFO_Uuid() }));
     }
 
     AZ::ComponentApplication* ROS2FrameComponentTestEnvironment::CreateApplicationInstance()
@@ -208,6 +214,234 @@ namespace UnitTest
             entity.Activate();
             EXPECT_STREQ(frame->GetNamespace().c_str(), newRootName.c_str());
         }
+    }
+
+    TEST_F(ROS2FrameComponentFixture, ComponentBusInterface)
+    {
+        ROS2::ROS2FrameConfiguration config;
+        config.m_frameName = "test_frame";
+        config.m_jointName = "test_joint";
+
+        AZ::Entity entity;
+        entity.SetName("test_entity");
+        entity.CreateComponent<AzFramework::TransformComponent>();
+        entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
+
+        entity.Init();
+        entity.Activate();
+
+        // Test component bus interface
+        AZStd::string namespace_result;
+        AZStd::string frameId_result;
+        AZStd::string jointName_result;
+        AZStd::string jointNameRaw_result;
+        AZStd::string frameName_result;
+        AZStd::string globalFrameName_result;
+
+        ROS2::ROS2FrameComponentBus::EventResult(namespace_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespace);
+        ROS2::ROS2FrameComponentBus::EventResult(frameId_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespacedFrameID);
+        ROS2::ROS2FrameComponentBus::EventResult(
+            jointName_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespacedJointName);
+        ROS2::ROS2FrameComponentBus::EventResult(jointNameRaw_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetJointName);
+        ROS2::ROS2FrameComponentBus::EventResult(frameName_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetFrameName);
+        ROS2::ROS2FrameComponentBus::EventResult(
+            globalFrameName_result, entity.GetId(), &ROS2::ROS2FrameComponentRequests::GetGlobalFrameName);
+
+        EXPECT_EQ(namespace_result, "test_entity");
+        EXPECT_EQ(frameId_result, "test_entity/test_frame");
+        EXPECT_EQ(jointName_result, "test_entity/test_joint");
+        EXPECT_EQ(jointNameRaw_result, "test_joint");
+        EXPECT_EQ(frameName_result, "test_frame");
+        EXPECT_EQ(globalFrameName_result, "test_entity/odom"); // Uses default global frame name
+    }
+
+    TEST_F(ROS2FrameComponentFixture, FrameTrackingInterfaceBasic)
+    {
+        auto trackingInterface = ROS2::ROS2FrameTrackingInterface::Get();
+        ASSERT_NE(trackingInterface, nullptr);
+
+        // Initially no frames should be registered
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), 0);
+        EXPECT_TRUE(trackingInterface->GetRegisteredFrames().empty());
+        EXPECT_TRUE(trackingInterface->GetAllNamespacedFrameIds().empty());
+
+        // Create and activate a frame component
+        ROS2::ROS2FrameConfiguration config;
+        config.m_frameName = "tracked_frame";
+
+        AZ::Entity entity;
+        entity.SetName("tracked_entity");
+        entity.CreateComponent<AzFramework::TransformComponent>();
+        entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
+
+        entity.Init();
+        entity.Activate();
+
+        // Frame should now be registered
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), 1);
+        EXPECT_TRUE(trackingInterface->IsFrameRegistered(entity.GetId()));
+        EXPECT_FALSE(trackingInterface->GetRegisteredFrames().empty());
+        EXPECT_EQ(trackingInterface->GetRegisteredFrames().size(), 1);
+        EXPECT_TRUE(trackingInterface->GetRegisteredFrames().contains(entity.GetId()));
+
+        // Check namespaced frame ID lookup
+        auto namespacedFrameId = trackingInterface->GetNamespacedFrameId(entity.GetId());
+        ASSERT_TRUE(namespacedFrameId.has_value());
+        EXPECT_STREQ(namespacedFrameId.value().c_str(), "tracked_entity/tracked_frame");
+
+        auto allFrameIds = trackingInterface->GetAllNamespacedFrameIds();
+        EXPECT_EQ(allFrameIds.size(), 1);
+        EXPECT_TRUE(allFrameIds.contains("tracked_entity/tracked_frame"));
+
+        // Check reverse lookup
+        auto foundEntityId = trackingInterface->GetFrameEntityByNamespacedId("tracked_entity/tracked_frame");
+        ASSERT_TRUE(foundEntityId.has_value());
+        EXPECT_EQ(foundEntityId.value(), entity.GetId());
+
+        // Deactivate entity and check frame is unregistered
+        entity.Deactivate();
+
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), 0);
+        EXPECT_FALSE(trackingInterface->IsFrameRegistered(entity.GetId()));
+        EXPECT_TRUE(trackingInterface->GetRegisteredFrames().empty());
+        EXPECT_TRUE(trackingInterface->GetAllNamespacedFrameIds().empty());
+    }
+
+    TEST_F(ROS2FrameComponentFixture, FrameTrackingInterfaceMultipleFrames)
+    {
+        auto trackingInterface = ROS2::ROS2FrameTrackingInterface::Get();
+        ASSERT_NE(trackingInterface, nullptr);
+
+        // Create multiple frame entities
+        constexpr int numFrames = 3;
+        std::vector<AZStd::unique_ptr<AZ::Entity>> entities;
+        std::vector<AZStd::string> expectedFrameIds;
+
+        for (int i = 0; i < numFrames; ++i)
+        {
+            ROS2::ROS2FrameConfiguration config;
+            config.m_frameName = AZStd::string::format("frame_%d", i);
+
+            auto entity = AZStd::make_unique<AZ::Entity>();
+            entity->SetName(AZStd::string::format("entity_%d", i));
+            entity->CreateComponent<AzFramework::TransformComponent>();
+            entity->CreateComponent<ROS2::ROS2FrameComponent>(config);
+
+            expectedFrameIds.push_back(AZStd::string::format("entity_%d/frame_%d", i, i));
+
+            entity->Init();
+            entity->Activate();
+
+            entities.push_back(AZStd::move(entity));
+        }
+
+        // Check all frames are registered
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), numFrames);
+        EXPECT_EQ(trackingInterface->GetRegisteredFrames().size(), numFrames);
+        EXPECT_EQ(trackingInterface->GetAllNamespacedFrameIds().size(), numFrames);
+
+        // Check each frame individually
+        for (int i = 0; i < numFrames; ++i)
+        {
+            EXPECT_TRUE(trackingInterface->IsFrameRegistered(entities[i]->GetId()));
+
+            auto namespacedFrameId = trackingInterface->GetNamespacedFrameId(entities[i]->GetId());
+            ASSERT_TRUE(namespacedFrameId.has_value());
+            EXPECT_EQ(namespacedFrameId.value(), expectedFrameIds[i]);
+
+            auto foundEntityId = trackingInterface->GetFrameEntityByNamespacedId(expectedFrameIds[i]);
+            ASSERT_TRUE(foundEntityId.has_value());
+            EXPECT_EQ(foundEntityId.value(), entities[i]->GetId());
+        }
+
+        // Deactivate one frame and check tracking updates
+        entities[1]->Deactivate();
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), numFrames - 1);
+        EXPECT_FALSE(trackingInterface->IsFrameRegistered(entities[1]->GetId()));
+        EXPECT_TRUE(trackingInterface->IsFrameRegistered(entities[0]->GetId()));
+        EXPECT_TRUE(trackingInterface->IsFrameRegistered(entities[2]->GetId()));
+
+        // Deactivate remaining frames
+        entities[0]->Deactivate();
+        entities[2]->Deactivate();
+        EXPECT_EQ(trackingInterface->GetRegisteredFrameCount(), 0);
+        EXPECT_TRUE(trackingInterface->GetRegisteredFrames().empty());
+    }
+
+    TEST_F(ROS2FrameComponentFixture, FrameTrackingInterfaceEdgeCases)
+    {
+        auto trackingInterface = ROS2::ROS2FrameTrackingInterface::Get();
+        ASSERT_NE(trackingInterface, nullptr);
+
+        // Test with invalid entity ID
+        AZ::EntityId invalidEntityId;
+        EXPECT_FALSE(trackingInterface->IsFrameRegistered(invalidEntityId));
+
+        auto invalidNamespacedFrameId = trackingInterface->GetNamespacedFrameId(invalidEntityId);
+        EXPECT_FALSE(invalidNamespacedFrameId.has_value());
+
+        // Test lookup with non-existent namespaced frame ID
+        auto invalidEntityLookup = trackingInterface->GetFrameEntityByNamespacedId("non_existent/frame");
+        EXPECT_FALSE(invalidEntityLookup.has_value());
+
+        // Test with entity that doesn't have a frame component
+        AZ::Entity entityWithoutFrame;
+        entityWithoutFrame.CreateComponent<AzFramework::TransformComponent>();
+        entityWithoutFrame.Init();
+        entityWithoutFrame.Activate();
+
+        EXPECT_FALSE(trackingInterface->IsFrameRegistered(entityWithoutFrame.GetId()));
+
+        auto noFrameNamespacedId = trackingInterface->GetNamespacedFrameId(entityWithoutFrame.GetId());
+        EXPECT_FALSE(noFrameNamespacedId.has_value());
+    }
+
+    TEST_F(ROS2FrameComponentFixture, FrameTrackingInterfaceNamespaceChanges)
+    {
+        auto trackingInterface = ROS2::ROS2FrameTrackingInterface::Get();
+        ASSERT_NE(trackingInterface, nullptr);
+
+        ROS2::ROS2FrameConfiguration config;
+        config.m_frameName = "dynamic_frame";
+        config.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Custom;
+        config.m_namespaceConfiguration.m_customNamespace = "initial_namespace";
+
+        AZ::Entity entity;
+        entity.SetName("dynamic_entity");
+        entity.CreateComponent<AzFramework::TransformComponent>();
+        auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
+
+        entity.Init();
+        entity.Activate();
+
+        // Check initial registration
+        EXPECT_TRUE(trackingInterface->IsFrameRegistered(entity.GetId()));
+        auto initialFrameId = trackingInterface->GetNamespacedFrameId(entity.GetId());
+        ASSERT_TRUE(initialFrameId.has_value());
+        EXPECT_EQ(initialFrameId.value(), "initial_namespace/dynamic_frame");
+
+        // Change namespace configuration
+        auto newConfig = frame->GetConfiguration();
+        newConfig.m_namespaceConfiguration.m_customNamespace = "updated_namespace";
+
+        entity.Deactivate();
+        frame->SetConfiguration(newConfig);
+        entity.Activate();
+
+        // Check updated registration
+        EXPECT_TRUE(trackingInterface->IsFrameRegistered(entity.GetId()));
+        auto updatedFrameId = trackingInterface->GetNamespacedFrameId(entity.GetId());
+        ASSERT_TRUE(updatedFrameId.has_value());
+        EXPECT_EQ(updatedFrameId.value(), "updated_namespace/dynamic_frame");
+
+        // Old frame ID should not exist anymore
+        auto oldEntityLookup = trackingInterface->GetFrameEntityByNamespacedId("initial_namespace/dynamic_frame");
+        EXPECT_FALSE(oldEntityLookup.has_value());
+
+        // New frame ID should work
+        auto newEntityLookup = trackingInterface->GetFrameEntityByNamespacedId("updated_namespace/dynamic_frame");
+        ASSERT_TRUE(newEntityLookup.has_value());
+        EXPECT_EQ(newEntityLookup.value(), entity.GetId());
     }
 
 } // namespace UnitTest

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -85,12 +85,12 @@ namespace UnitTest
         entity.Init();
         entity.Activate();
 
-        const std::string jointName(frame->GetNamespacedJointName().GetCStr());
+        const std::string jointName(frame->GetNamespacedJointName().c_str());
         const std::string frameId(frame->GetNamespacedFrameID().c_str());
 
         EXPECT_EQ(entity.GetState(), AZ::Entity::State::Active);
-        EXPECT_STRCASEEQ(jointName.c_str(), ("o3de_" + entityName + "/").c_str());
-        EXPECT_STRCASEEQ(frameId.c_str(), ("o3de_" + entityName + "/sensor_frame").c_str());
+        EXPECT_STRCASEEQ(jointName.c_str(), (entityName + "/").c_str());
+        EXPECT_STRCASEEQ(frameId.c_str(), (entityName + "/sensor_frame").c_str());
     }
 
     TEST_F(ROS2FrameComponentFixture, ThreeFramesDefault)
@@ -127,7 +127,7 @@ namespace UnitTest
 
         for (int i = 0; i < numOfEntities; i++)
         {
-            const std::string jointName(frames[i]->GetNamespacedJointName().GetCStr());
+            const std::string jointName(frames[i]->GetNamespacedJointName().c_str());
             const std::string frameId(frames[i]->GetNamespacedFrameID().c_str());
 
             EXPECT_EQ(entities[i]->GetState(), AZ::Entity::State::Active);
@@ -148,21 +148,47 @@ namespace UnitTest
         entity.Init();
         entity.Activate();
 
-        auto rosifiedName = "o3de_" + entityName;
+        auto rosifiedName = entityName;
         ASSERT_STREQ(frame->GetNamespace().c_str(), rosifiedName.c_str());
 
         // Note that namespace parameter is only applied using Custom strategy
-        frame->UpdateNamespaceConfiguration("MyCustomNamespace", ROS2::NamespaceConfiguration::NamespaceStrategy::Custom);
-        EXPECT_STREQ(frame->GetNamespace().c_str(), "MyCustomNamespace");
+        {
+            auto configuration = frame->GetConfiguration();
+            entity.Deactivate();
+            configuration.m_namespaceConfiguration.m_customNamespace = "MyCustomNamespace";
+            configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Custom;
+            frame->SetConfiguration(configuration);
+            entity.Activate();
+            EXPECT_STREQ(frame->GetNamespace().c_str(), "MyCustomNamespace");
+        }
+
         // Empty strategy clears the namespace
-        frame->UpdateNamespaceConfiguration("MyCustomNamespace", ROS2::NamespaceConfiguration::NamespaceStrategy::Empty);
-        EXPECT_STREQ(frame->GetNamespace().c_str(), "");
+        {
+            auto configuration = frame->GetConfiguration();
+            configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Empty;
+            entity.Deactivate();
+            frame->SetConfiguration(configuration);
+            entity.Activate();
+            EXPECT_STREQ(frame->GetNamespace().c_str(), "");
+        }
         // From Entity Name strategy uses rosified version of Entity Name
-        frame->UpdateNamespaceConfiguration("MyCustomNamespace", ROS2::NamespaceConfiguration::NamespaceStrategy::FromEntityName);
-        EXPECT_STREQ(frame->GetNamespace().c_str(), rosifiedName.c_str());
+        {
+            auto configuration = frame->GetConfiguration();
+            configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::FromEntityName;
+            entity.Deactivate();
+            frame->SetConfiguration(configuration);
+            entity.Activate();
+            EXPECT_STREQ(frame->GetNamespace().c_str(), rosifiedName.c_str());
+        }
         // Default strategy is like From Entity Name strategy if the entity is on top of hierarchy ...
-        frame->UpdateNamespaceConfiguration("MyCustomNamespace", ROS2::NamespaceConfiguration::NamespaceStrategy::Default);
-        EXPECT_STREQ(frame->GetNamespace().c_str(), rosifiedName.c_str());
+        {
+            auto configuration = frame->GetConfiguration();
+            configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Default;
+            entity.Deactivate();
+            frame->SetConfiguration(configuration);
+            entity.Activate();
+            EXPECT_STREQ(frame->GetNamespace().c_str(), rosifiedName.c_str());
+        }
 
         AZ::Entity newRootEntity;
         AZStd::string newRootName = "new_root";
@@ -174,8 +200,14 @@ namespace UnitTest
         AZ::TransformBus::Event(entity.GetId(), &AZ::TransformBus::Events::SetParent, newRootEntity.GetId());
 
         // If there is a parent Default strategy concatenates parent's namespace with rosified name
-        frame->UpdateNamespaceConfiguration("MyCustomNamespace", ROS2::NamespaceConfiguration::NamespaceStrategy::Default);
-        EXPECT_STREQ(frame->GetNamespace().c_str(), AZStd::string::format("%s/%s", newRootName.c_str(), rosifiedName.c_str()).c_str());
+        {
+            auto configuration = frame->GetConfiguration();
+            configuration.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Default;
+            entity.Deactivate();
+            frame->SetConfiguration(configuration);
+            entity.Activate();
+            EXPECT_STREQ(frame->GetNamespace().c_str(), newRootName.c_str());
+        }
     }
 
 } // namespace UnitTest

--- a/Gems/ROS2/Code/ros2_api_files.cmake
+++ b/Gems/ROS2/Code/ros2_api_files.cmake
@@ -14,6 +14,7 @@ set(FILES
     Include/ROS2/Frame/NamespaceConfiguration.h
     Include/ROS2/Frame/ROS2FrameComponent.h
     Include/ROS2/Frame/ROS2FrameConfiguration.h
+    Include/ROS2/Frame/ROS2FrameComponentBus.h
     Include/ROS2/Frame/ROS2Transform.h
     Include/ROS2/Sensor/SensorConfiguration.h
     Include/ROS2/Sensor/SensorConfigurationRequestBus.h

--- a/Gems/ROS2/Code/ros2_private_files.cmake
+++ b/Gems/ROS2/Code/ros2_private_files.cmake
@@ -20,6 +20,8 @@ set(FILES
     Source/Clock/RealTimeSource.h
     Source/Frame/NamespaceConfiguration.cpp
     Source/Frame/ROS2FrameConfiguration.cpp
+    Source/Frame/ROS2FrameGameSystemComponent.cpp
+    Source/Frame/ROS2FrameGameSystemComponent.h
     Source/SimulationUtils/FollowingCameraConfiguration.cpp
     Source/SimulationUtils/FollowingCameraConfiguration.h
     Source/SimulationUtils/FollowingCameraComponent.cpp

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/functional.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include <ROS2/Frame/ROS2FrameEditorComponentBus.h>
 #include <ROS2Controllers/Manipulation/Controllers/JointsPositionControllerRequests.h>
 #include <ROS2Controllers/Manipulation/JointInfo.h>
@@ -105,8 +106,8 @@ namespace ROS2Controllers
         AZStd::function<void(const AZ::Entity* entity)> getAllJointsHierarchy = [&](const AZ::Entity* entity)
         {
             AZ::Name jointName;
-            ROS2::ROS2FrameEditorComponentBus::EventResult(
-                jointName, entity->GetId(), &ROS2::ROS2FrameEditorComponentBus::Events::GetNamespacedJointName);
+            ROS2::ROS2FrameComponentBus::EventResult(
+                jointName, entity->GetId(), &ROS2::ROS2FrameComponentBus::Events::GetNamespacedJointName);
 
             const AZStd::string jointNameStr = jointName.GetCStr();
             const bool hasNonFixedJoints = JointUtils::HasNonFixedJoints(entity);

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -82,8 +82,8 @@ namespace ROS2Controllers
         AZStd::function<void(const AZ::Entity* entity)> getAllJointsHierarchy = [&](const AZ::Entity* entity)
         {
             AZ::Name jointName;
-            ROS2::ROS2FrameEditorComponentBus::EventResult(
-                jointName, entity->GetId(), &ROS2::ROS2FrameEditorComponentBus::Events::GetNamespacedJointName);
+            ROS2::ROS2FrameComponentBus::EventResult(
+                jointName, entity->GetId(), &ROS2::ROS2FrameComponentBus::Events::GetNamespacedJointName);
 
             const AZStd::string jointNameStr = jointName.GetCStr();
             const bool hasNonFixedJoints = JointUtils::HasNonFixedJoints(entity);


### PR DESCRIPTION
## What does this PR do?

This PR continues the work done in mp/rework_frame. It fixes wrong implementation of namespace generation. Implements not finished TODOs, adds a EBus for getting namespaced names of frames, adds a tracking interface, that allows to find frames based on the namespaced frame ids.

## How was this PR tested?

By running the tests, and manually checking if the generated TF2 trees are valid and expected.
